### PR TITLE
added tests for forwardsample and backward filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /docs/build/
+*.DS_STORE

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 julia = "1"

--- a/test/filter_test.jl
+++ b/test/filter_test.jl
@@ -1,0 +1,59 @@
+using MitosisStochasticDiffEq
+using Test
+using LinearAlgebra
+
+# set true model parameters
+p = [-0.1,0.2,0.9]
+# define SDE function
+f(u,p,t) = p[1]*u + p[2] - 1.5*sin.(u*2pi)
+g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
+
+# time span
+tstart = 0.0
+tend = 1.0
+dt = 0.02
+
+# intial condition
+u0 = 1.1
+
+# set estimated parameters Eq.~(2.2)
+pest = [-0.1,0.2,1.3]
+
+kernel = MitosisStochasticDiffEq.SDEKernel(f,g,u0,tstart,tend,pest,p=p,dt=dt)
+
+
+# initial values for ODE
+mynames = (:logscale, :μ, :Σ);
+myvalues = [0.0, 0.0, 10.0];
+NT = NamedTuple{mynames}(myvalues)
+
+solend, message = MitosisStochasticDiffEq.backwardfilter(kernel, NT)
+
+
+
+"""
+    backwardfilter() -> ps, p0, c
+Backward filtering using the Euler method, starting with `N(ν, P)` prior
+and integration scale c2 between observations
+
+"""
+function backwardfilter((c, ν, P)::NamedTuple{(:logscale, :μ, :Σ)}, p, s)
+    ps = [[ν, P, c]]
+    B, β, σ̃ = p
+    for i in eachindex(s)[end-1:-1:1]
+        dt = s[i+1] - s[i]
+        H = inv(P)
+        F = H*ν
+        P = P - dt*(B*P + P*B' - σ̃*σ̃')
+        ν = ν - dt*(B*ν + β)
+        c = c - dt*tr(B)
+        push!(ps, [ν, P, c])
+    end
+    [ν, P, c], ps
+end
+
+
+solend2, message2 = backwardfilter(NT, pest, reverse(message.t))
+
+@test isapprox(solend, solend2, rtol=1e-12)
+@test isapprox(Array(message), reduce(hcat, message2), rtol=1e-12)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using MitosisStochasticDiffEq
 using Test
 
+include("sample_test.jl")
+include("filter_test.jl")
+
 @testset "MitosisStochasticDiffEq.jl" begin
     # Write your tests here.
 end

--- a/test/sample_test.jl
+++ b/test/sample_test.jl
@@ -1,0 +1,43 @@
+using MitosisStochasticDiffEq
+using Test
+
+# set true model parameters
+p = [-0.1,0.2,0.9]
+# define SDE function
+f(u,p,t) = p[1]*u + p[2] - 1.5*sin.(u*2pi)
+g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
+
+# time span
+tstart = 0.0
+tend = 1.0
+dt = 0.02
+
+# intial condition
+u0 = 1.1
+
+# set estimated parameters Eq.~(2.2)
+pest = [-0.1,0.2,1.3]
+
+kernel = MitosisStochasticDiffEq.SDEKernel(f,g,u0,tstart,tend,pest,p=p,dt=dt)
+
+# sample using MitosisStochasticDiffEq and EM default
+sol = MitosisStochasticDiffEq.sample(kernel, save_noise=true)
+
+
+"""
+forwardsample(f, g, p, s, W, x) using the Euler-Maruyama scheme
+on a time-grid s with associated noise values W
+"""
+function forwardsample(f, g, p, s, Ws, x)
+    xs = typeof(x)[]
+    for i in eachindex(s)[1:end-1]
+        dt = s[i+1] - s[i]
+        push!(xs, x)
+        x = x + f(x, p, s[i])*dt + g(x, p, s[i])*(Ws[i+1]-Ws[i])
+    end
+    push!(xs, x)
+
+    return xs
+end
+
+@test isapprox(sol.u, forwardsample(f,g,p,sol.t,sol.W.W,sol.prob.u0), atol=1e-12)


### PR DESCRIPTION
I added tests for the forward sampling and backward filtering in case of a scalar, 1D SDE.

For scalar, multi-dimensional SDEs, we will want to pass additional keywords like `noise_rate_prototype` and `noise` to the constructors, e.g., for
```
prob = SDEProblem(f, g, u0, (tstart,tend), p, noise=noise, ..)
```

For other cases, e.g., when  P is a matrix and v is a vector, we probably need to vectorize the backward filtering ODE, which currently reads:
```
dP = B*P + P*B' - σtil*σtil'
dν = B*ν + β
```

If everything is working, we should also consider to speed-up the ODE by using a non-allocating form [`filterODE!(du, u, p, t)`]