### PR TITLE
fix backward filter for multivariate inputs

### DIFF
--- a/src/MitosisStochasticDiffEq.jl
+++ b/src/MitosisStochasticDiffEq.jl
@@ -37,11 +37,11 @@ end
 
 myunpack(a) = a
 myunpack(a::ArrayPartition) = a.x
-mypack(a...) = ArrayPartition(a...)
+mypack(a,b,c) = ArrayPartition(a,b,[c])
 mypack(a::Number...) = [a...]
 
 
-function backwardfilter(k::SDEKernel, (c, ν, P)::NamedTuple{(:logscale, :μ, :Σ)}; alg=Euler())
+function backwardfilter(k::SDEKernel, (c, ν, P)::NamedTuple{(:logscale, :μ, :Σ)}; alg=Euler(), inplace=false)
     @unpack tstart, tend, plin, dt = k
 
     trange = (tend, tstart)
@@ -58,14 +58,30 @@ function backwardfilter(k::SDEKernel, (c, ν, P)::NamedTuple{(:logscale, :μ, :�
       H = inv(P)
       F = H*ν
 
-      dP = B*P + P*B' - σtil*σtil'
-      dν = B*ν + β
+      dP = B*P + P*B' .- σtil*σtil'
+      dν = B*ν .+ β
       dc = tr(B)
 
       return mypack(dν, dP, dc)
     end
 
-    prob = ODEProblem(filterODE, u0, trange, plin)
+    function filterODE(du, u, p, t)
+      B, β, σtil = p
+
+      # take care for multivariate case here if P isa Matrix, ν  isa Vector, c isa Scalar
+      ν, P, c = myunpack(u)
+
+      H = inv(P)
+      F = H*ν
+
+      du.x[1] .= B*ν .+ β
+      du.x[2] .= B*P + P*B' .- σtil*σtil'
+      du.x[3] .= tr(B)
+
+      return nothing
+    end
+
+    prob = ODEProblem{inplace}(filterODE, u0, trange, plin)
     sol = solve(prob, alg, dt=dt)
     message = sol
     return sol[end], message


### PR DESCRIPTION
An `ArrayPartition` which contains a float has problems when multiplied with another float (such as `dt` in the Euler step), since the float inside the `ArrayPartition` then becomes a zero-dimensional array. To fix this I updated the `mypack` function

```julia
mypack(a,b,c) = ArrayPartition(a,b,[c])
```

I also added tests for the multivariate case and a iip version for the update rule.