### PR TITLE
Test forward

### DIFF
--- a/test/outest.jl
+++ b/test/outest.jl
@@ -104,7 +104,8 @@ we((x,c)) = x*exp(c)
 samples = [we(MitosisStochasticDiffEq.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)[1][:,end]) for k in 1:K]
 
 @show std(samples)
+ptrue = Mitosis.density(p, [u0])
 p̃ = Mitosis.density(WGaussian{(:F,:Γ,:c)}(solend[2]\solend[1], inv(solend[2]), solend[3]), u0)
 @testset "Mitosis tilted forward" begin
-    @test_broken pT.μ[] ≈ mean(samples)*p̃ atol=0.02
+    @test pT.μ[] ≈ mean(samples)*p̃/ptrue atol=0.02
 end

--- a/test/outest.jl
+++ b/test/outest.jl
@@ -78,7 +78,7 @@ pT = kᵒ([u0])
 
 # initial values for ODE
 mynames = (:logscale, :μ, :Σ);
-myvalues = [0.0, y_, 0.1]; # start with observation μ=y with uncertainty Σ=10
+myvalues = [0.0, y_, 0.1]; # start with observation μ=y with uncertainty Σ=0.1
 NT = NamedTuple{mynames}(myvalues)
 solend, message = MitosisStochasticDiffEq.backwardfilter(sdekernel, NT)
 
@@ -95,7 +95,7 @@ samples = [MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (u0, 0.0),
 end
 
 
-# try titled forward
+# try tilted forward
 
 solend, message = MitosisStochasticDiffEq.backwardfilter(sdekernel2, NT)
 solfw, ll = MitosisStochasticDiffEq.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)

--- a/test/outest.jl
+++ b/test/outest.jl
@@ -20,7 +20,7 @@ tstart = 0.0
 tend = 1.0
 dt = 0.02
 
-# intial condition
+# initial condition
 u0 = 1.1
 
 # set of linear parameters Eq.~(2.2)

--- a/test/outest.jl
+++ b/test/outest.jl
@@ -1,46 +1,53 @@
 #using Revise
 using Mitosis, MitosisStochasticDiffEq, Statistics
 using LinearAlgebra, Test
-
+using Random
+Random.seed!(124)
 using Mitosis: AffineMap
 
 # set true model parameters
-p = [-0.1, 0.0, 0.9]
+par = [-0.1, 0.0, 0.9]
 
 # Samples
-K = 400
+K = 800
 
 # define SDE function
-f(u,p,t) = p[1]*u + p[2]
-g(u,p,t) = p[3]
+f(u,p,t) = p[1]*u .+ p[2]
+g(u,p,t) = p[3] .+ 0u # needs to preserve type of u for forwardguided
 
 # time span
 tstart = 0.0
 tend = 1.0
 dt = 0.02
 
-# initial condition
+# intial condition
 u0 = 1.1
 
 # set of linear parameters Eq.~(2.2)
-plin = copy(p)
-pest = [2.0]
-sdekernel = MitosisStochasticDiffEq.SDEKernel(f,g,tstart,tend,pest,plin,p=p,dt=dt)
+plin = copy(par)
+pest = copy(par)
+sdekernel = MitosisStochasticDiffEq.SDEKernel(f,g,tstart,tend,pest,plin,p=par,dt=dt)
+
+plin2 = [-0.05, 0.07, 1.0]
+sdekernel2 = MitosisStochasticDiffEq.SDEKernel(f,g,tstart,tend,pest,plin2,p=par,dt=dt)
+
+
+
 sol, y_ = MitosisStochasticDiffEq.sample(sdekernel, u0, save_noise=true)
 y = vcat(y_)
 samples_ = [MitosisStochasticDiffEq.sample(sdekernel, u0, save_noise=true)[2] for k in 1:K]
 samples = vcat.(samples_)
 
 # Compute transition density. See Ludvig Arnold (ISBN 9780486482361 ), also Proposition 3.5. in [1]
-B = fill(p[1], 1, 1)
+B = fill(par[1], 1, 1)
 Φ = exp(B*(tend - tstart))
 β = fill(0.0, 1)
-Σ = fill(p[3]^2, 1, 1)
+Σ = fill(par[3]^2, 1, 1)
 Λ = lyap(B, Σ)
 Q = Λ - Φ*Λ*Φ'
 
 
-gkernel = kernel(Gaussian; μ=AffineMap(Φ, β), Σ=ConstantMap(Q))
+gkernel = Mitosis.kernel(Gaussian; μ=AffineMap(Φ, β), Σ=ConstantMap(Q))
 
 p = gkernel([u0])
 p̂ = Gaussian{(:μ, :Σ)}(mean(samples), cov(samples))
@@ -49,16 +56,55 @@ p̂ = Gaussian{(:μ, :Σ)}(mean(samples), cov(samples))
 
 
 
-m, p = backwardfilter(gkernel, y)
+m, p = Mitosis.backwardfilter(gkernel, y)
 # initial values for ODE
 mynames = (:logscale, :μ, :Σ);
-myvalues = [0.0, y_, 0.0];
+myvalues = [0.0, y_, 0.0]; # start with observation μ=y with uncertainty Σ=0
 NT = NamedTuple{mynames}(myvalues)
 
 solend, message = MitosisStochasticDiffEq.backwardfilter(sdekernel, NT)
 
-@testset "Mitosis" begin
+@testset "Mitosis backward" begin
     @test (p.c)[] ≈ solend[3]
     @test (p.Γ\p.F)[] ≈ solend[1] atol=0.02
     @test inv(p.Γ)[] ≈ solend[2] atol=0.02
+end
+
+# Try forward
+m, p = Mitosis.backwardfilter(gkernel, WGaussian{(:F, :Γ, :c)}(y*10.0, 10.0I, 0.0))
+kᵒ = Mitosis.left′(BFFG(), gkernel, m)
+
+pT = kᵒ([u0])
+
+# initial values for ODE
+mynames = (:logscale, :μ, :Σ);
+myvalues = [0.0, y_, 0.1]; # start with observation μ=y with uncertainty Σ=10
+NT = NamedTuple{mynames}(myvalues)
+solend, message = MitosisStochasticDiffEq.backwardfilter(sdekernel, NT)
+
+solfw, ll = MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)
+
+@test ll == 0
+
+samples = [MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)[1][1,end] for k in 1:K]
+
+@testset "Mitosis forward" begin
+    @test pT.μ[] ≈ mean(samples) atol=0.02
+    @test pT.Σ[] ≈ cov(samples) atol=0.02
+
+end
+
+
+# try titled forward
+
+solend, message = MitosisStochasticDiffEq.backwardfilter(sdekernel2, NT)
+solfw, ll = MitosisStochasticDiffEq.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)
+
+we((x,c)) = x*exp(c)
+samples = [we(MitosisStochasticDiffEq.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)[1][:,end]) for k in 1:K]
+
+@show std(samples)
+p̃ = Mitosis.density(WGaussian{(:F,:Γ,:c)}(solend[2]\solend[1], inv(solend[2]), solend[3]), u0)
+@testset "Mitosis tilted forward" begin
+    @test_broken pT.μ[] ≈ mean(samples)*p̃ atol=0.02
 end


### PR DESCRIPTION
I test that forward guiding in the case where the true drift is linear corresponds to the discrete transitions in Mitosis (not quite working if the true drift is linear, but the linear approximation is different.)