### PR TITLE
use ForwardDiff to compute Jacobian

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MeasureTheory = "eadaa1a4-d27c-401d-8699-e962e1bbc33b"
 Mitosis = "e74b8d68-74d0-42b9-99ba-91d43d3ab0e8"

--- a/src/MitosisStochasticDiffEq.jl
+++ b/src/MitosisStochasticDiffEq.jl
@@ -13,6 +13,8 @@ using UnPack
 using Statistics
 using StaticArrays
 
+using ForwardDiff
+
 outer_(x) = x*x'
 outer_(x::Number) = Diagonal([x*x'])
 outer_(x::AbstractVector) = Diagonal(x.*x)
@@ -22,5 +24,6 @@ include("sample.jl")
 include("filter.jl")
 include("guiding.jl")
 include("regression.jl")
+include("derivative_utils.jl")
 
 end

--- a/src/derivative_utils.jl
+++ b/src/derivative_utils.jl
@@ -1,0 +1,22 @@
+mutable struct ParamJacobianWrapper{fType,tType,uType} <: Function
+  f::fType
+  t::tType
+  u::uType
+end
+
+(ff::ParamJacobianWrapper)(p) = ff.f(ff.u,p,ff.t)
+
+function calc_J!(ϕ, r::Regression, p, t)
+  @unpack fjac!, y = r
+
+  if fjac! !== nothing
+    fjac!(ϕ, y, p, t)
+  else
+    @unpack pf = r
+    pf.t = t
+    pf.u = y
+    ForwardDiff.jacobian!(ϕ, pf, p)
+  end
+
+  return nothing
+end

--- a/src/regression.jl
+++ b/src/regression.jl
@@ -4,19 +4,19 @@ function conjugate(r::Regression, Y, Γ0::AbstractArray)
 end
 
 function conjugate(r::Regression, Y, prior::Gaussian)
-    @unpack k, fjac!, ϕ0func!, ϕ, ϕ0, y, y2 = r
+    @unpack k, fjac!, ϕ0func!, ϕ, ϕ0, y, y2, θ = r
     @unpack g, pest = k
 
     t = Y.t[1]
     y .= Y.u[1]
 
-    fjac!(ϕ, y, pest, t)
+    calc_J!(ϕ, r, θ, t)
     μ = prior.F
     Γ = prior.Γ
 
     for i in 1:length(Y)-1
-        fjac!(ϕ, y, pest, t)
-        Gϕ = pinv(g(y, pest, t)*g(y, pest, t)')*ϕ
+        calc_J!(ϕ, r, θ, t)
+        Gϕ = pinv(outer_(g(y, pest, t)))*ϕ
         zi = ϕ'*Gϕ
         t2 = Y.t[i + 1]
         y2 .= Y.u[i + 1]

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -47,5 +47,5 @@ ll0 = randn()
 samples1 = [MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (x0, ll0))[1][1,end] for k in 1:K]
 samples2 = MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (x0, ll0), numtraj=K)[1][1,end,:]
 
-@test isapprox(mean(samples1), mean(samples2), rtol=5e-3)
+@test isapprox(mean(samples1), mean(samples2), rtol=1e-2)
 @test isapprox(cov(samples1), cov(samples2), rtol=1e-2)

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -28,8 +28,8 @@ sdekernel = MitosisStochasticDiffEq.SDEKernel(f,g,tstart,tend,pest,plin,dt=dt)
 samples1 = MitosisStochasticDiffEq.sample(sdekernel, u0, K, save_noise=false).u
 samples2 = [MitosisStochasticDiffEq.sample(sdekernel, u0, save_noise=false)[2] for _ in 1:K]
 
-@test isapprox(mean(samples1), mean(samples2), rtol=5e-3)
-@test isapprox(cov(samples1), cov(samples2), rtol=5e-3)
+@test isapprox(mean(samples1), mean(samples2), rtol=1e-2)
+@test isapprox(cov(samples1), cov(samples2), rtol=1e-2)
 
 
 


### PR DESCRIPTION
Adds ForwardDiff to compute `\phi` if `param_jac` is not specified in Regression.

