### PR TITLE
allow for usage of time change function

### DIFF
--- a/src/filter.jl
+++ b/src/filter.jl
@@ -59,14 +59,14 @@ function filterODE(du, u, p, t)
 end
 
 function backwardfilter(k::SDEKernel, p::WGaussian{(:μ, :Σ, :c)}; alg=Euler(),
-    inplace=false, apply_timechange=false)
+    inplace=false, apply_timechange=false, abstol=1e-6, reltol=1e-3)
   message, solend = backwardfilter(k::SDEKernel, NamedTuple{(:logscale, :μ, :Σ)}((p.c, p.μ, p.Σ));
-    alg=alg, inplace=inplace, apply_timechange=apply_timechange)
+    alg=alg, inplace=inplace, apply_timechange=apply_timechange, abstol=abstol, reltol=reltol)
   return message, WGaussian{(:μ, :Σ, :c)}(myunpack(solend)...)
 end
 
 function backwardfilter(k::SDEKernel, (c, ν, P)::NamedTuple{(:logscale, :μ, :Σ)};
-    alg=Euler(), inplace=false, apply_timechange=false)
+    alg=Euler(), inplace=false, apply_timechange=false, abstol=1e-6,reltol=1e-3)
   @unpack trange, p = k
 
   # Initialize OD
@@ -74,7 +74,7 @@ function backwardfilter(k::SDEKernel, (c, ν, P)::NamedTuple{(:logscale, :μ, :�
 
   prob = ODEProblem{inplace}(filterODE, u0, reverse(get_tspan(trange)), p)
   if !apply_timechange
-    sol = solve(prob, alg, dt = get_dt(trange))
+    sol = solve(prob, alg, dt = get_dt(trange), abstol=abstol, reltol=reltol)
   else
     _ts = timechange(trange)
     sol = solve(prob, alg, tstops=_ts)

--- a/src/guiding.jl
+++ b/src/guiding.jl
@@ -1,7 +1,7 @@
 function range2ind(ts::AbstractRange, t)
   indx = round(Int, (t-first(ts))/step(ts))
   indx += one(indx)
-  indx = maximum((minimum((indx,one(indx))),length(ts)))
+  indx = minimum((maximum((indx,one(indx))),length(ts)))
   return indx
 end
 
@@ -103,7 +103,7 @@ end
 function forwardguiding(k::SDEKernel, message, (x0, ll0), Z=nothing; alg=EM(false),
     dt=get_dt(k.trange), isadaptive=StochasticDiffEq.isadaptive(alg),
     numtraj=nothing, ensemblealg=EnsembleThreads(), output_func=(sol,i) -> (sol,false),
-    inplace=true, tstops=nothing, kwargs...)
+    inplace=true, kwargs...)
 
   @unpack f, g, trange, p = k
 
@@ -119,19 +119,19 @@ function forwardguiding(k::SDEKernel, message, (x0, ll0), Z=nothing; alg=EM(fals
   end
 
   if numtraj==nothing
-    if tstops===nothing
-      sol = solve(prob, alg, dt=dt, adaptive=isadaptive; kwargs...)
+    if !isadaptive
+      sol = solve(prob, alg, tstops=message.ts; kwargs...)
     else
-      sol = solve(prob, alg, tstops=tstops; kwargs...)
+      sol = solve(prob, alg, dt=dt, adaptive=isadaptive, tstops=message.ts; kwargs...)
     end
   else
     ensembleprob = EnsembleProblem(prob, output_func = output_func)
-    if tstops===nothing
+    if !isadaptive
       sol = solve(ensembleprob, alg, ensemblealg=ensemblealg,
-        dt=dt, adaptive=isadaptive, trajectories=numtraj; kwargs...)
+        tstops=message.ts, trajectories=numtraj; kwargs...)
     else
       sol = solve(ensembleprob, alg, ensemblealg=ensemblealg,
-        tstops=tstops, trajectories=numtraj; kwargs...)
+        dt=dt, adaptive=isadaptive, tstops=message.ts, trajectories=numtraj; kwargs...)
     end
   end
 

--- a/src/guiding.jl
+++ b/src/guiding.jl
@@ -109,6 +109,9 @@ function forwardguiding(k::SDEKernel, message, (x0, ll0), Z=nothing; alg=EM(fals
 
   u0 = mypack(x0,ll0)
 
+  # check that message.ts is sorted
+  !issorted(message.ts) && error("Something went wrong. Message.ts is not sorted! Please report this.")
+
   guided_f = GuidingDriftCache(k,message)
   guided_g = GuidingDiffusionCache(g)
 
@@ -122,7 +125,7 @@ function forwardguiding(k::SDEKernel, message, (x0, ll0), Z=nothing; alg=EM(fals
     if !isadaptive
       sol = solve(prob, alg, tstops=message.ts; kwargs...)
     else
-      sol = solve(prob, alg, dt=dt, adaptive=isadaptive, tstops=message.ts; kwargs...)
+      sol = solve(prob, alg, dt=dt, adaptive=isadaptive; kwargs...)
     end
   else
     ensembleprob = EnsembleProblem(prob, output_func = output_func)
@@ -131,7 +134,7 @@ function forwardguiding(k::SDEKernel, message, (x0, ll0), Z=nothing; alg=EM(fals
         tstops=message.ts, trajectories=numtraj; kwargs...)
     else
       sol = solve(ensembleprob, alg, ensemblealg=ensemblealg,
-        dt=dt, adaptive=isadaptive, tstops=message.ts, trajectories=numtraj; kwargs...)
+        dt=dt, adaptive=isadaptive, trajectories=numtraj; kwargs...)
     end
   end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,9 +12,13 @@ struct Message{kernelType,solType,sol2Type,tType}
   ts::tType
 end
 
-function Message(sol, sdekernel::SDEKernel)
+function Message(sol, sdekernel::SDEKernel, apply_timechange=false)
   soldis = reverse(Array(sol), dims=2)
-  ts = reverse(sol.t)
+  if OrdinaryDiffEq.isadaptive(sol.alg) || apply_timechange
+    ts = reverse(sol.t)
+  else
+    ts = sdekernel.trange
+  end
   Message{typeof(sdekernel),typeof(sol),typeof(soldis),typeof(ts)}(sdekernel,sol,soldis,ts)
 end
 

--- a/test/filter_test.jl
+++ b/test/filter_test.jl
@@ -106,7 +106,7 @@ end
   message, solend = MitosisStochasticDiffEq.backwardfilter(kernel, NT)
   message2, solend2 = backwardfilter(NT, plin, message.ts)
 
-  @test isapprox(solend.x[1], solend2[1], rtol=1e-15)
+  @test isapprox(solend.x[1], solend2[1], rtol=1e-14)
   @test isapprox(solend.x[2], solend2[2], rtol=1e-14)
   @test isapprox(solend.x[3][1], solend2[3], rtol=1e-14)
 

--- a/test/guiding_test.jl
+++ b/test/guiding_test.jl
@@ -379,7 +379,7 @@ end
   ll0 = randn()
 
   solfw, ll = MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (x0, ll0);
-    isadaptive=false, tstops=message.ts)
+    isadaptive=false)
 
   @test isapprox(solfw.t, message.ts, rtol=1e-10)
   @test isapprox(solfw.t, MitosisStochasticDiffEq.timechange(trange), rtol=1e-10)

--- a/test/guiding_test.jl
+++ b/test/guiding_test.jl
@@ -343,3 +343,46 @@ end
 # savefig(pl,"adaptive_guiding.png")
 
 end
+
+@testset "timechange Guiding tests" begin
+  Random.seed!(12345)
+  # set true model parameters
+  p = [-0.1,0.2,0.9]
+
+  # set of linear parameters Eq.~(2.2)
+  B, β, σ̃ = -0.1, 0.2, 1.3
+  plin = [B, β, σ̃]
+  pest = [-0.4, 0.5, 1.4] # initial guess of parameter to be estimated
+
+  # time span
+  tstart = 0.0
+  tend = 1.0
+  dt = 0.001
+  trange = tstart:dt:tend
+
+  # intial condition
+  u0 = 1.1
+
+  # forward kernel
+  sdekernel = MitosisStochasticDiffEq.SDEKernel(f,g,trange,pest)
+
+  # initial values for ODE
+  mynames = (:logscale, :μ, :Σ);
+  myvalues = [0.0, 0.0, 10.0];
+  NT = NamedTuple{mynames}(myvalues)
+
+  # backward kernel
+  kerneltilde = MitosisStochasticDiffEq.SDEKernel(Mitosis.AffineMap(B, β), Mitosis.ConstantMap(σ̃), trange, plin)
+  message, backward = MitosisStochasticDiffEq.backwardfilter(kerneltilde, NT, apply_timechange=true)
+
+  x0 = randn()
+  ll0 = randn()
+
+  solfw, ll = MitosisStochasticDiffEq.forwardguiding(sdekernel, message, (x0, ll0);
+    isadaptive=false, tstops=message.ts)
+
+  @test isapprox(solfw.t, message.ts, rtol=1e-10)
+  @test isapprox(solfw.t, MitosisStochasticDiffEq.timechange(trange), rtol=1e-10)
+  @test length(solfw.t) == length(trange)
+
+end


### PR DESCRIPTION
- if a non-adaptive solver is used, this now allows to store `message.ts` as a range instead of a vector, and thus speed up the index extraction in `forwardguiding`.
- `timechange` function can be applied to `backwardfilter` and `forwardguiding`, see #17 .