### PR TITLE
[WIP] check backward ODE with static arrays for linear parameters

### DIFF
--- a/src/guiding.jl
+++ b/src/guiding.jl
@@ -87,7 +87,7 @@ function (G::GuidingDriftCache)(u,p,t)
     dl = ..
     dx = ..
   end
-  
+
   return mypack(dx, dl)
 end
 
@@ -105,7 +105,7 @@ function (G::GuidingDiffusionCache)(u,p,t)
 
   x = @view u[1:end-1]
   dx = g(x,p,t)
-  return mypack(dx, 0.0)
+  return mypack(dx, zero(eltype(u)))
 end
 
 


### PR DESCRIPTION
Started to check: 
https://github.com/mschauer/MitosisStochasticDiffEq.jl/issues/61

Based on the stacktrace it seems to be a type instability issue:
`ArrayPartition{Float64{},Tuple{Vector{Float64},Array{Float64{},2},Array{Float64{},1}}}`
vs.
`ArrayPartition{Float64{},Tuple{SVector{2, Float64},Array{Float64{},2},Array{Float64{},1}}}`

What I have already checked now is that using static arrays for \theta_{lin} works.
