### PR TITLE
constant diffusity flag

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -1,14 +1,24 @@
-function sample(k::SDEKernel, u0; alg=EM(false),kwargs...)
+function sample(k::SDEKernel, u0; Z=nothing, alg=EM(false),kwargs...)
   @unpack f, g, trange, p = k
-  prob = SDEProblem(f, g, u0, get_tspan(trange), p)
+  if Z===nothing
+    prob = SDEProblem(f, g, u0, get_tspan(trange), p)
+  else
+    prob = SDEProblem(f, g, u0, get_tspan(trange), p, noise=Z)
+  end
   sol = solve(prob, alg, dt = get_dt(trange); kwargs...)
   return sol, sol[end]
 end
 
 function sample(k::SDEKernel, u0, numtraj, ensemblealg=EnsembleThreads(),
-    output_func=(sol,i) -> (sol[end],false); alg=EM(false),kwargs...)
+    output_func=(sol,i) -> (sol[end],false); Z=nothing, alg=EM(false),kwargs...)
   @unpack f, g, trange, p = k
-  prob = SDEProblem(f, g, u0, get_tspan(trange), p)
+
+  if Z===nothing
+    prob = SDEProblem(f, g, u0, get_tspan(trange), p)
+  else
+    prob = SDEProblem(f, g, u0, get_tspan(trange), p, noise=Z)
+  end
+
   ensembleprob = EnsembleProblem(prob, output_func = output_func)
 
   sol = solve(ensembleprob, alg, ensemblealg, dt = get_dt(trange), trajectories=numtraj; kwargs...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,6 +3,12 @@ struct SDEKernel{fType,gType,tType,pType}
   g::gType
   trange::tType
   p::pType
+  constant_diffusity::Bool
+end
+
+function SDEKernel(f,g,trange,p=nothing,constant_diffusity=false)
+  SDEKernel{typeof(f),typeof(g),typeof(trange),typeof(p),typeof(constant_diffusity)}(f,
+    g,trange,p,constant_diffusity)
 end
 
 abstract type AbstractFilteringAlgorithm end


### PR DESCRIPTION
Allows one to simplify the computation of the log-likelihood in the guiding terms, see https://github.com/mschauer/MitosisStochasticDiffEq.jl/issues/63 and adds the possibility to pass a noise process to `sample`.