### PR TITLE
Fixes for the Lyapunov filter

### DIFF
--- a/test/lyapunovfilter_test.jl
+++ b/test/lyapunovfilter_test.jl
@@ -3,6 +3,7 @@ using Mitosis
 using Test, Random
 using LinearAlgebra
 using OrdinaryDiffEq
+Random.seed!(12345)
 @testset "backward Lyapunov filtering tests" begin
   # define SDE function
   f(u,p,t) = p[1]*u .+ p[2]
@@ -20,9 +21,9 @@ using OrdinaryDiffEq
 
   # initial values for ODE
   mynames = (:logscale, :μ, :Σ);
-  c = 0.0
-  ν = 0.0
-  P = 10.0
+  c = randn()
+  ν = randn()
+  P = 10*rand()
   myvalues = [c, ν, P]
   NT = NamedTuple{mynames}(myvalues)
 
@@ -51,7 +52,6 @@ using OrdinaryDiffEq
       Mitosis.AffineMap(B, β), Mitosis.ConstantMap(σ̃), trange, [B, β, σ̃]
   )
 
-  Random.seed!(12345)
   c = randn()
   ν = randn(dim)
   P = randn(dim,dim)

--- a/test/lyapunovfilter_test.jl
+++ b/test/lyapunovfilter_test.jl
@@ -84,8 +84,8 @@ Random.seed!(12345)
   message2, solend2 = MitosisStochasticDiffEq.backwardfilter(kernel, NT,
     filter=MitosisStochasticDiffEq.LyapunovFilter())
 
-  @test message.soldis[1:dim,:] ≈ message2.soldis[1:dim,:] rtol=1e-2
-  @test message.soldis[dim+1:dim+dim*dim,:] ≈ message2.soldis[dim+1:dim+dim*dim,:] rtol=1e-1
+  @test message.soldis[1:dim,:] ≈ message2.soldis[1:dim,:] rtol=1e-10
+  @test message.soldis[dim+1:dim+dim*dim,:] ≈ message2.soldis[dim+1:dim+dim*dim,:] rtol=1e-10
   @test message.soldis[end,:] ≈ message2.soldis[end,:] rtol=1e-10
-  @test solend2 ≈ solend rtol=1e-1
+  @test solend2 ≈ solend rtol=1e-10
 end

--- a/test/lyapunovfilter_test.jl
+++ b/test/lyapunovfilter_test.jl
@@ -84,8 +84,8 @@ Random.seed!(12345)
   message2, solend2 = MitosisStochasticDiffEq.backwardfilter(kernel, NT,
     filter=MitosisStochasticDiffEq.LyapunovFilter())
 
-  @test message.soldis[1:dim,:] ≈ message2.soldis[1:dim,:] rtol=1e-10
-  @test message.soldis[dim+1:dim+dim*dim,:] ≈ message2.soldis[dim+1:dim+dim*dim,:] rtol=1e-10
-  @test message.soldis[end,:] ≈ message2.soldis[end,:] rtol=1e-10
-  @test solend2 ≈ solend rtol=1e-10
+  @test message.soldis[1:dim,:] ≈ message2.soldis[1:dim,:] rtol=1e-9
+  @test message.soldis[dim+1:dim+dim*dim,:] ≈ message2.soldis[dim+1:dim+dim*dim,:] rtol=1e-9
+  @test message.soldis[end,:] ≈ message2.soldis[end,:] rtol=1e-9
+  @test solend2 ≈ solend rtol=1e-9
 end


### PR DESCRIPTION
There was a problem with the DE solution for nu.  The 1D test works now perfectly:
```julia
@test message.soldis[1,:] ≈ message2.soldis[1,:] rtol=1e-10
@test message.soldis[2,:] ≈ message2.soldis[2,:] rtol=1e-10 
@test message.soldis[3,:] ≈ message2.soldis[3,:] rtol=1e-10
@test isapprox(solend, solend2, rtol=1e-10)
```
For the multivariate test example, there might still be an issue because the solutions for nu and P do not agree very well with the covariance filter:
```julia
@test message.soldis[1:dim,:] ≈ message2.soldis[1:dim,:] rtol=1e-2
@test message.soldis[dim+1:dim+dim*dim,:] ≈ message2.soldis[dim+1:dim+dim*dim,:] rtol=1e-1
```