### PR TITLE
Static Array fixes

### DIFF
--- a/src/filter.jl
+++ b/src/filter.jl
@@ -23,10 +23,11 @@ function backwardfilter(k::SDEKernel, (c, μ, Σ)::NamedTuple{(:logscale, :μ, :
 end
 
 # covariance filter ODE Eqs.
-compute_dP(B,P,σtil) = B*P + P*B' - outer_(σtil)
+compute_dP(B,P,σtil) = convert(typeof(P), B*P + P*B' - outer_(σtil))
 compute_dP(B,P::SArray,σtil::Number) = B*P + P*B' - σtil*σtil'*similar_type(P, Size(size(P,1),size(P,1)))(I)
+
 compute_dν(B,ν,β::Number) = B*ν .+ β
-compute_dν(B,ν,β) = B*ν + β
+compute_dν(B,ν,β) = convert(typeof(ν),B*ν + β)
 
 function compute_dP!(dP,B,P,σtil)
   dP .= B*P + P*B' - outer_(σtil)

--- a/test/static_array_test.jl
+++ b/test/static_array_test.jl
@@ -138,4 +138,65 @@ end
   @test isapprox(backwardstat.x[1], backward.x[1], rtol=1e-10)
   @test isapprox(backwardstat.x[2], backward.x[2], rtol=1e-10)
   @test isapprox(backwardstat.x[3], backward.x[3], rtol=1e-10)
+
+  # mixed cases
+  message1, backward1 = MitosisStochasticDiffEq.backwardfilter(tildekernel, NTstat)
+  @test typeof(backward1.x[1]) <: SArray
+  @test typeof(backward1.x[2]) <: SArray
+  @test typeof(backward1.x[3]) <: SArray
+
+  @test isapprox(backward1.x[1], backward.x[1], rtol=1e-10)
+  @test isapprox(backward1.x[2], backward.x[2], rtol=1e-10)
+  @test isapprox(backward1.x[3], backward.x[3], rtol=1e-10)
+
+  message2, backward2 = MitosisStochasticDiffEq.backwardfilter(tildekernelstat, NT)
+  @test !(typeof(backward2.x[1]) <: SArray)
+  @test !(typeof(backward2.x[2]) <: SArray)
+  @test !(typeof(backward2.x[3]) <: SArray)
+
+  @test isapprox(backward2.x[1], backward.x[1], rtol=1e-10)
+  @test isapprox(backward2.x[2], backward.x[2], rtol=1e-10)
+  @test isapprox(backward2.x[3], backward.x[3], rtol=1e-10)
+
+  # backward
+  (c, μ, Pmat) = NT
+  p = tildekernel.p
+  u0 = MitosisStochasticDiffEq.mypack(μ, Pmat, c)
+  MitosisStochasticDiffEq.CovarianceFilterODE(u0, p, 0.0)
+  b, β, σtil = p
+  MitosisStochasticDiffEq.compute_dν(b,μ,β)
+  MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)
+  @test typeof(MitosisStochasticDiffEq.compute_dν(b,μ,β)) == typeof(μ)
+  @test typeof(MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)) == typeof(Pmat)
+
+  # backwardstat
+  (c, μ, Pmat) = NTstat
+  p = tildekernelstat.p
+  u0 = MitosisStochasticDiffEq.mypack(μ, Pmat, c)
+  MitosisStochasticDiffEq.CovarianceFilterODE(u0, p, 0.0)
+  b, β, σtil = p
+  MitosisStochasticDiffEq.compute_dν(b,μ,β)
+  MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)
+  @test typeof(MitosisStochasticDiffEq.compute_dν(b,μ,β)) == typeof(μ)
+  @test typeof(MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)) == typeof(Pmat)
+
+  # backward1
+  (c, μ, Pmat) = NTstat
+  p = tildekernel.p
+  u0 = MitosisStochasticDiffEq.mypack(μ, Pmat, c)
+  MitosisStochasticDiffEq.CovarianceFilterODE(u0, p, 0.0)
+  b, β, σtil = p
+  MitosisStochasticDiffEq.compute_dν(b,μ,β)
+  MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)
+  @test typeof(MitosisStochasticDiffEq.compute_dν(b,μ,β)) == typeof(μ)
+  @test typeof(MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)) == typeof(Pmat)
+
+  # backward2
+  (c, μ, Pmat) = NT
+  p = tildekernelstat.p
+  u0 = MitosisStochasticDiffEq.mypack(μ, Pmat, c)
+  MitosisStochasticDiffEq.CovarianceFilterODE(u0, p, 0.0)
+  b, β, σtil = p
+  @test typeof(MitosisStochasticDiffEq.compute_dν(b,μ,β)) == typeof(μ)
+  @test typeof(MitosisStochasticDiffEq.compute_dP(b,Pmat,σtil)) == typeof(Pmat)
 end


### PR DESCRIPTION
fixes https://github.com/mschauer/MitosisStochasticDiffEq.jl/issues/61. 

The type of, e.g., nu changed from `StaticVector` to `Vector`  and vice versa.
Previously it worked only when:
```julia
message, backward = MitosisStochasticDiffEq.backwardfilter(tildekernel, NT)
```
or 
```julia

message, backward = MitosisStochasticDiffEq.backwardfilter(tildekernelstat, NTstat)
```
was used.

Now, mixtures like:
```julia
message, backward = MitosisStochasticDiffEq.backwardfilter(tildekernelstat, NT)
```
or 
```julia
message, backward = MitosisStochasticDiffEq.backwardfilter(tildekernel, NTstat)
```
should work as well.
