### PR TITLE
Continuation #71 internal solver

### DIFF
--- a/src/solver.jl
+++ b/src/solver.jl
@@ -34,6 +34,9 @@ function exponential_map!(x::Union{SArray,Number}, dx, P)
   x + dx
 end
 
+function saveit!(uu::Vector, u::Tuple{Int, Float64, T}, P) where {T}
+  push!(uu, (u[1], u[2], copy(u[3])))
+end
 saveit!(uu, u, P) = push!(uu, deepcopy(u))
 saveit!(::Nothing, u, P) = nothing
 

--- a/test/performance/solver_performance.jl
+++ b/test/performance/solver_performance.jl
@@ -42,10 +42,12 @@ function MSDE.dZ!(u, dz, Z, P::customP)
   (Z[i+1][1] - Z[i][1], Z[i+1][2] - Z[i][2], dw)
 end
 
+# mul!(C, A, B, α, β) -> C = A B α + C β.
 
 @inline function MSDE.tangent!(du, u, dz, P::customP)
   x = du[3] 
-  @. x = P.θ[1][]*u[3]*dz[2] + P.θ[2]*dz[2] + P.θ[3]*u[3]*dz[3] 
+  mul!(x, P.θ[1], u[3], dz[2], false)
+  @. x += P.θ[2]*dz[2] + P.θ[3]*u[3]*dz[3] 
   (dz[1], dz[2], x)
 end
 

--- a/test/performance/solver_performance.jl
+++ b/test/performance/solver_performance.jl
@@ -10,18 +10,18 @@ f(u,p,t) = p[1]*u + p[2]
 g(u,p,t) = p[3]*u
 
 f!(du,u,p,t) = (du .= p[1]*u + p[2])
-g!(du,u,p,t) = (du .= p[3]*u)
+g!(du,u,p,t) = (@. du = p[3]*u)
 function gstep!(dx, _, u, p, t, dw, _)
-  dx .+= (p[3]*u).*dw 
+  @. dx += (p[3]*u)*dw 
 end
 # time span
 tstart = 0.0
 tend = 1.0
-dt = 0.002
+dt = 0.005
 trange = tstart:dt:tend
 
 B, β, σ̃ = -fill(0.1,1,1), [0.2], 1.3
-p = [B, β, σ̃]
+p = (B, β, σ̃)
 
 u0 = rand(1)
 
@@ -35,15 +35,23 @@ struct customP{θType}
   θ::θType
 end
 
-@inline function MSDE.tangent!(du, u, dz, P::customP)
-  du[3][] = (P.θ[1][]*u[3][] + P.θ[2][])*dz[2][] + P.θ[3]*dz[3][]
+function MSDE.dZ!(u, dz, Z, P::customP)
+  i = u[1]
+  dw = dz[3]
+  @. dw = Z[i+1][3] -  Z[i][3]
+  (Z[i+1][1] - Z[i][1], Z[i+1][2] - Z[i][2], dw)
+end
 
-  (dz[1], dz[2], du[3])
+
+@inline function MSDE.tangent!(du, u, dz, P::customP)
+  x = du[3] 
+  @. x = P.θ[1][]*u[3]*dz[2] + P.θ[2]*dz[2] + P.θ[3]*u[3]*dz[3] 
+  (dz[1], dz[2], x)
 end
 
 @inline function MSDE.exponential_map!(u, du, P::customP)
   x = u[3]
-  x[] += du[3][]
+  @. x += du[3]
   (u[1] + du[1], u[2] + du[2], x)
 end
 
@@ -59,21 +67,22 @@ sol4, solend4 = @btime MSDE.sample(k_iip2, u0, EM(false), NG)
 sol5, solend5 = @btime MSDE.sample(k_iip2, u0, MSDE.EulerMaruyama!(), Ws)
 sol6, solend6 = @btime MSDE.sample(k_iip2, u0, MSDE.EulerMaruyama!(), Ws, P=customP(p))
 
+Z = collect(zip(1:length(trange), trange, Ws))
+u = (1, 0.0, copy(u0))
+dz = (0, 0.0, [0.0])
+du = (0, 0.0, [0.0])
+_, solend7 = MSDE.solve!(MSDE.EulerMaruyama!(), nothing, u, Z, customP(p))
+
 @test solend1 ≈ solend2[3] rtol=1e-8
 @test solend1 ≈ solend3 rtol=1e-8
 @test solend1 ≈ solend4 rtol=1e-8
 @test solend1 ≈ solend5[3] rtol=1e-8
 @test solend1 ≈ solend6[3] rtol=1e-8
+@test solend1 ≈ solend7[3] rtol=1e-8
 
-Z = collect(zip(1:length(trange), trange, [[w] for w in [0; sqrt(1/length(trange))*cumsum(randn(length(trange)))]]))
-u = (1, 0.0, [1.0])
+
+
+u = (1, 0.0, copy(u0))
 dz = (0, 0.0, [0.0])
-du = (0, 0.0, [0.0])
-
-uu, uT = MSDE.solve!(MSDE.EulerMaruyama!(), nothing, u, Z, customP(p))
-@btime MSDE.solve!(MSDE.EulerMaruyama!(), nothing, u, Z, customP(p))
-
-
-
-
-
+@btime MSDE.solve!(MSDE.EulerMaruyama!(), nothing, deepcopy(u), Z, customP(p))
+;


### PR DESCRIPTION
Continuation #71. Make everything work,  baseline level "impossible"

```
  177.795 μs (2429 allocations: 178.70 KiB) # oop  EM(false), NG
  129.806 μs (1625 allocations: 175.11 KiB)
  156.413 μs (1830 allocations: 113.41 KiB) # iip EM(false), NG)
  153.056 μs (1830 allocations: 113.41 KiB)
  101.020 μs (1425 allocations: 156.36 KiB) # MSDE.EulerMaruyama!(), Ws)
  60.179 μs (1028 allocations: 118.95 KiB) # MSDE.EulerMaruyama!(), Ws, P=customP(p))
  7.660 μs (14 allocations: 1.19 KiB) # direct call MSDE.solve!(MSDE.EulerMaruyama!()
 ```
