### PR TITLE
Use tstops in sample

### DIFF
--- a/src/sample.jl
+++ b/src/sample.jl
@@ -30,7 +30,7 @@ function _sample(k::Union{SDEKernel,SDEKernel!}, u0, alg::Union{StochasticDiffEq
   @unpack f, g, trange, p = k
 
   prob = construct_sample_Problem(k, u0, Z, alg)
-  sol = solve(prob, alg, dt = get_dt(trange); kwargs...)
+  sol = solve(prob, alg, tstops = trange; kwargs...)
   return sol, sol[end]
 end
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -34,7 +34,7 @@ function exponential_map!(x::Union{SArray,Number}, dx, P)
   x + dx
 end
 
-function saveit!(uu::Vector, u::Tuple{Int, Float64, T}, P) where {T}
+function saveit!(uu::AbstractVector, u::Tuple{Int, Float64, T}, P) where {T}
   push!(uu, (u[1], u[2], copy(u[3])))
 end
 saveit!(uu, u, P) = push!(uu, deepcopy(u))


### PR DESCRIPTION
Using `dt` has the problem that the solver might miss the `tend` in the last step and does an extra step breaking things down the road:

```
julia> [sol1.t  [diff(sol1.t);""]]
100002×2 Matrix{Any}:
 0.0      1.0e-5
 1.0e-5   1.0e-5
 2.0e-5   1.0e-5
 3.0e-5   1.0e-5
 4.0e-5   1.0e-5
 5.0e-5   1.0e-5
 ⋮
 0.99996  1.0e-5
 0.99997  1.0e-5
 0.99998  1.0e-5
 0.99999  1.0e-5
 1.0      1.91624e-12
 1.0       ""
```

Using `tstops` without `dt` seems to work fine, let's see if that is the solution for guiding as well.