### PR TITLE
WIP: fix outputs of `sample` and `forwardguiding`

### DIFF
--- a/example/bridgeexample.jl
+++ b/example/bridgeexample.jl
@@ -36,10 +36,9 @@ WG = (;logscale = 0.0, μ=uT, Σ=SMatrix{4,4}(Diagonal([0.0000001, 0.0000001, 0.
 
 message, solend = MSDE.backwardfilter(kerneltilde, WG)
 
-solfw, ll = MSDE.forwardguiding(sdekernel, message, (u0, 0.0),
+ts, u, uend, noise, ll = MSDE.forwardguiding(sdekernel, message, (u0, 0.0),
    Z=nothing; inplace=false, save_noise=true)
 
-u = solfw.u
 using Makie
 pl = lines(getindex.(u, 1), getindex.(u, 2))
 #lines!(pl, getindex.(u, 3), getindex.(u, 4), color=:blue)

--- a/src/MitosisStochasticDiffEq.jl
+++ b/src/MitosisStochasticDiffEq.jl
@@ -5,6 +5,7 @@ using RecursiveArrayTools
 using StochasticDiffEq
 using OrdinaryDiffEq
 using DiffEqNoiseProcess
+import DiffEqNoiseProcess.pCN
 using LinearAlgebra
 using Random
 using UnPack
@@ -14,6 +15,8 @@ using ForwardDiff
 using PaddedViews
 
 import SciMLBase.isinplace
+
+export pCN
 
 include("types.jl")
 include("sample.jl")

--- a/src/guiding.jl
+++ b/src/guiding.jl
@@ -143,7 +143,22 @@ function construct_forwardguiding_Problem(k::Union{SDEKernel,SDEKernel!}, messag
     guided_g = GuidingDiffusionCache(g,padded_size)
   end
 
-  prob = SDEProblem{inplace}(guided_f, guided_g, u0, get_tspan(trange), p, noise=Z,
+  if Z===nothing
+    noise = Z
+  else
+    if Z.curW isa AbstractVector
+      if Z isa DiffEqNoiseProcess.NoiseGrid
+        noise = AugmentedNoiseGrid(Z.t,Z.W,Z.Z)
+      else
+        error("Please pass a NoiseGrid to forwardguiding.")
+      end
+    else
+      # scalar case
+      noise = Z
+    end
+  end
+
+  prob = SDEProblem{inplace}(guided_f, guided_g, u0, get_tspan(trange), p, noise=noise,
                              noise_rate_prototype=_noise_rate_prototype)
 
   return prob
@@ -180,7 +195,7 @@ end
 
 function _forwardguiding(k::SDEKernel, message, (x0, ll0), alg::Union{StochasticDiffEqAlgorithm,StochasticDiffEqRODEAlgorithm}, Z;
     dt=dt, isadaptive=StochasticDiffEq.isadaptive(alg),
-    numtraj=nothing, ensemblealg=EnsembleThreads(), output_func=(sol,i) -> (sol,false),
+    numtraj=nothing, ensemblealg=EnsembleThreads(), output_func=(sol,i) -> (sol[end],false),
     inplace=inplace, kwargs...)
 
   @unpack f, g, trange, p = k
@@ -196,7 +211,12 @@ function _forwardguiding(k::SDEKernel, message, (x0, ll0), alg::Union{Stochastic
     else
       sol = solve(prob, alg, dt=dt, adaptive=isadaptive; kwargs...)
     end
-    return sol.t, [x[1:length(x0)] for x in sol.u], sol.u[end], sol.W, sol[end][end]
+    if Z===nothing
+      W = [x[1:length(x0)] for x in sol.W.W]
+    else
+      W = Z.W
+    end
+    return (sol[end][1:length(x0)],sol[end][end]), (sol.t, [x[1:length(x0)] for x in sol.u], W)
   else
     ensembleprob = EnsembleProblem(prob, output_func = output_func)
     if !isadaptive
@@ -206,7 +226,7 @@ function _forwardguiding(k::SDEKernel, message, (x0, ll0), alg::Union{Stochastic
       sol = solve(ensembleprob, alg, ensemblealg=ensemblealg,
           dt=dt, adaptive=isadaptive, trajectories=numtraj; kwargs...)
     end
-    return sol, sol[end][end]
+    return ([x[1:length(x0)] for x in sol.u], last.(sol.u)), nothing
   end
 end
 
@@ -224,7 +244,12 @@ function _forwardguiding(k::SDEKernel, message, (x0, ll0), alg::AbstractInternal
     uu = nothing
   end
   uu, uT = solve!(alg, uu, u, Z, P)
-  return getindex.(uu,2), getindex.(uu,3), uT[3], getindex.(Z,3), uT[end]
+  if save
+    rest = (getindex.(uu,2), getindex.(uu,3), getindex.(Z,3))
+  else
+    rest = nothing
+  end
+  return (uT[3],uT[end]), rest
 end
 
 function tangent!(du, u, dz, P::GuidedSDE!)

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -36,7 +36,7 @@ function _sample(k::Union{SDEKernel,SDEKernel!}, u0, alg::Union{StochasticDiffEq
 
   prob = construct_sample_Problem(k, u0, Z, alg)
   sol = solve(prob, alg, tstops = trange; kwargs...)
-  return sol.t, sol.u, sol[end], sol.W
+  return sol[end], (sol.t, sol.u, sol.W.W)
 end
 
 
@@ -51,10 +51,11 @@ function _sample(k::Union{SDEKernel,SDEKernel!}, u0, alg::AbstractInternalSolver
   end
   uu, uT = solve!(alg, uu, u, Z, P)
   if save
-    return getindex.(uu,2), getindex.(uu,3), uT[end], Z
+    rest = (getindex.(uu,2), getindex.(uu,3), getindex.(Z,3))
   else
-    return nothing, nothing, uT[end], getindex.(Z,3)
+    rest = (nothing, nothing, getindex.(Z,3))
   end
+  return uT[end], rest
 end
 
 
@@ -67,7 +68,7 @@ function sample(k::Union{SDEKernel,SDEKernel!}, u0, numtraj::Number, alg=EM(fals
   ensembleprob = EnsembleProblem(prob, output_func = output_func)
 
   sol = solve(ensembleprob, alg, ensemblealg, dt = get_dt(trange), trajectories=numtraj; kwargs...)
-  return sol
+  return sol.u
 end
 
 

--- a/src/sample.jl
+++ b/src/sample.jl
@@ -36,7 +36,7 @@ function _sample(k::Union{SDEKernel,SDEKernel!}, u0, alg::Union{StochasticDiffEq
 
   prob = construct_sample_Problem(k, u0, Z, alg)
   sol = solve(prob, alg, tstops = trange; kwargs...)
-  return sol, sol[end]
+  return sol.t, sol.u, sol[end], sol.W
 end
 
 
@@ -50,7 +50,11 @@ function _sample(k::Union{SDEKernel,SDEKernel!}, u0, alg::AbstractInternalSolver
     uu = nothing
   end
   uu, uT = solve!(alg, uu, u, Z, P)
-  return uu, uT
+  if save
+    return getindex.(uu,2), getindex.(uu,3), uT[end], Z
+  else
+    return nothing, nothing, uT[end], getindex.(Z,3)
+  end
 end
 
 

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -27,9 +27,10 @@ par = [-0.2, 0.1, 0.9]
 plin = copy(par)
 sdekernel = MSDE.SDEKernel(f,g,trange,par)
 
+
 @testset "ensemble sampling tests" begin
-  samples1 = MSDE.sample(sdekernel, u0, K, save_noise=false).u
-  samples2 = [MSDE.sample(sdekernel, u0, save_noise=false)[3] for _ in 1:K]
+  samples1 = MSDE.sample(sdekernel, u0, K, save_noise=false)
+  samples2 = [MSDE.sample(sdekernel, u0, save_noise=false)[1] for _ in 1:K]
 
   @test isapprox(mean(samples1), mean(samples2), rtol=1e-2)
   @test isapprox(cov(samples1), cov(samples2), rtol=1e-2)
@@ -56,10 +57,10 @@ ll0 = randn()
 
 samples1 = []
 for k=1:K
-  push!(samples1, MSDE.forwardguiding(sdekernel, message, (x0, ll0))[2][end][1])
+  push!(samples1, MSDE.forwardguiding(sdekernel, message, (x0, ll0))[1][1])
 end
 
-samples2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), numtraj=K)[1][1,end,:]
+samples2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), numtraj=K)[1][1]
 
 @testset "ensemble guiding tests" begin
   @test isapprox(mean(samples1), mean(samples2), rtol=1e-2)

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -29,7 +29,7 @@ sdekernel = MSDE.SDEKernel(f,g,trange,par)
 
 @testset "ensemble sampling tests" begin
   samples1 = MSDE.sample(sdekernel, u0, K, save_noise=false).u
-  samples2 = [MSDE.sample(sdekernel, u0, save_noise=false)[2] for _ in 1:K]
+  samples2 = [MSDE.sample(sdekernel, u0, save_noise=false)[3] for _ in 1:K]
 
   @test isapprox(mean(samples1), mean(samples2), rtol=1e-2)
   @test isapprox(cov(samples1), cov(samples2), rtol=1e-2)
@@ -54,7 +54,7 @@ end
 x0 = 1.34
 ll0 = randn()
 
-samples1 = [MSDE.forwardguiding(sdekernel, message, (x0, ll0))[1][1,end] for k in 1:K]
+samples1 = [MSDE.forwardguiding(sdekernel, message, (x0, ll0))[2][end,1] for k in 1:K]
 samples2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), numtraj=K)[1][1,end,:]
 
 @testset "ensemble guiding tests" begin

--- a/test/ensemble_test.jl
+++ b/test/ensemble_test.jl
@@ -54,7 +54,11 @@ end
 x0 = 1.34
 ll0 = randn()
 
-samples1 = [MSDE.forwardguiding(sdekernel, message, (x0, ll0))[2][end,1] for k in 1:K]
+samples1 = []
+for k=1:K
+  push!(samples1, MSDE.forwardguiding(sdekernel, message, (x0, ll0))[2][end][1])
+end
+
 samples2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), numtraj=K)[1][1,end,:]
 
 @testset "ensemble guiding tests" begin

--- a/test/guiding_test.jl
+++ b/test/guiding_test.jl
@@ -49,9 +49,9 @@ function forwardguiding(plin, pest, s, (x, ll), ps, Z=randn(length(s)), noisetyp
         ll += llstep(x, r, t, P, noisetype)*dt # accumulate log-likelihood
 
         if noisetype == :scalar
-            noise = g(x,pest,t)*Z[i] #sqrt(dt)*Z[i]
+            noise = g(x,pest,t)*Z[i][] #sqrt(dt)*Z[i]
         elseif noisetype ==:diag
-            noise = g(x,pest,t).*Z[:,i]
+            noise = g(x,pest,t).*Z[i]
         elseif noisetype ==:nondiag
             noise = g(x,pest,t)*Z[:,i]
         else
@@ -106,10 +106,10 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
   x0 = randn()
   ll0 = randn()
 
-  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
+  (uend1, ll), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
 
 
-  dWs = (noise1[1,2:end]-noise1[1,1:end-1])
+  dWs = (noise1[2:end]-noise1[1:end-1])
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs)
 
@@ -140,7 +140,7 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
 
   x0 = randn(dim)
   ll0 = randn()
-  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG)
+  (uend1, ll), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG)
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0), ps, W)
@@ -167,9 +167,9 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
   x0 = randn(dim)
   ll0 = randn()
 
-  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
+  (uend1, ll), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
 
-  dWs = noise1[1:dim,2:end]-noise1[1:dim,1:end-1]
+  dWs = noise1[2:end]-noise1[1:end-1]
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs,:diag)
@@ -213,9 +213,9 @@ end
   x0 = randn()
   ll0 = randn()
 
-  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
+  (uend1, ll), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
 
-  dWs = (noise1[1,2:end]-noise1[1,1:end-1])
+  dWs = (noise1[2:end]-noise1[1:end-1])
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs)
 
@@ -246,7 +246,7 @@ end
 
   x0 = randn(dim)
   ll0 = randn()
-  ts1, u1, uend1, noise1, ll  = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG, inplace=false)
+  (uend1, ll), (ts1, u1, noise1)  = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG, inplace=false)
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0), ps, W)
@@ -273,10 +273,10 @@ end
   x0 = randn(dim)
   ll0 = randn()
 
-  ts1, u1, uend1, noise1, ll  = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
+  (uend1, ll), (ts1, u1, noise1)  = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
 
   Ws = Array(noise1)
-  dWs = Ws[1:dim,2:end]-Ws[1:dim,1:end-1]
+  dWs = Ws[2:end]-Ws[1:end-1]
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs,:diag)
@@ -327,11 +327,11 @@ end
   x0 = randn()
   ll0 = randn()
 
-  ts1, u1, uend1, _, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
+  (uend1, ll), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
             W; dt=dt, isadaptive=false)
-  ts2, u2, uend2, _, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
+  (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
             W; dt=dt, isadaptive=true)
-  ts3, u3, uend3, _, ll3 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), SOSRI(),
+  (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), SOSRI(),
             W; dt=dt, isadaptive=true)
 
   @test isapprox(ll, ll2, rtol=1e-1)
@@ -344,8 +344,6 @@ end
 
   @show length(ts1), length(ts2), length(ts3)
 end
-
-
 
 @testset "timechange Guiding tests" begin
   Random.seed!(12345)
@@ -381,13 +379,14 @@ end
   x0 = randn()
   ll0 = randn()
 
-  ts, u, uend, _, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0);
+  (uend, ll), (ts, u, noise) = MSDE.forwardguiding(sdekernel, message, (x0, ll0);
     isadaptive=false)
 
   @test isapprox(ts, message.ts, rtol=1e-10)
   @test isapprox(ts, MSDE.timechange(trange), rtol=1e-10)
   @test length(ts) == length(trange)
 end
+
 
 @testset "Reuse of noise values tests" begin
   Random.seed!(12345)
@@ -430,27 +429,24 @@ end
   ll0 = randn()
 
   # test two subsequent evaluations with same Brownian motion given by NoiseGrid
-  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
-  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
+  (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
+  (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
 
   @test isapprox(ll1, ll2, rtol=1e-14)
   @test isapprox(u1, u2, rtol=1e-14)
-  @test isapprox(noise1.W, noise2.W, rtol=1e-14)
-  @test isapprox(noise1.W, W.W, rtol=1e-14)
+  @test isapprox(noise1, noise2, rtol=1e-14)
+  @test isapprox(noise1, W.W, rtol=1e-14)
 
   # test pCN with \rho = 1
-  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
+  (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
+  Z = pCN(ts1, noise1, 1.0)
 
-  Z = pCN(noise1, 1.0)
-
-  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
+  (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
 
   @test isapprox(ll1, ll2, rtol=1e-14)
   @test isapprox(u1, u2, rtol=1e-14)
-  @test isapprox(noise1.W, noise1.W, rtol=1e-14)
-  @test isapprox(noise1.W, Z.W, rtol=1e-14)
-  @test W.W != Z.W
-
+  @test isapprox(noise1, noise1, rtol=1e-14)
+  @test isapprox(noise1, Z.W, rtol=1e-14)
 
   # test pCN with ρ = 0.2 (decrease dt for test)
   ρ = 0.2
@@ -459,26 +455,26 @@ end
   # backward kernel
   kerneltilde = MSDE.SDEKernel(Mitosis.AffineMap(B, β), Mitosis.ConstantMap(σ̃), trange, plin)
   message, backward = MSDE.backwardfilter(kerneltilde, NT)
-  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
+  (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
 
-  Z = pCN(noise1, ρ)
+  Z = pCN(ts1, noise1, ρ)
 
-  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
+  (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
 
   computedW(W, indx, dt) = (W[indx+1][1]-W[indx][1])/sqrt(dt) # likelihood part can be ignored
   dWnew = []
   dWold = []
   for i in 1:length(ts1[1:end-1])
-    push!(dWnew,computedW(noise1.W,i,dt))
-    push!(dWold,computedW(noise2.W,i,dt))
+    push!(dWnew,computedW(noise1,i,dt))
+    push!(dWold,computedW(noise2,i,dt))
   end
   @show cor(dWnew,dWold)
   @test ≈(cor(dWnew,dWold),ρ,rtol=1e-1)
 end
 
 
-
 @testset "flag-constant and matrix-valued diffusivity tests" begin
+
   Random.seed!(12345)
 
   ## define model (two traits, as in phylo)
@@ -513,9 +509,9 @@ end
   κ̃ = MSDE.SDEKernel(Mitosis.AffineMap(θlin[1], θlin[2]), Mitosis.ConstantMap(θlin[3]), trange, θlin)
 
   # forward sample
-  ts, x, xT, noise = MSDE.sample(κ1, u0; save_noise=true)
-  Z = NoiseWrapper(noise)
-  _, x2, xT2,_ = MSDE.sample(κ2, u0, EM(false), Z)
+  xT, (ts, x, noise) = MSDE.sample(κ1, u0; save_noise=true)
+  Z = pCN(ts, noise, 1)
+  xT2, (_, x2, _) = MSDE.sample(κ2, u0, EM(false), Z)
 
   @test x ≈ x2
   @test xT ≈ xT2
@@ -535,13 +531,13 @@ end
   x0 = randn(d)
   ll0 = randn()
 
-  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(κg1, message, (x0, ll0); save_noise=true)
-  Z = pCN(noise1, 1.0)
-  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(κg2, message, (x0, ll0), EM(false), Z)
+  (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(κg1, message, (x0, ll0); save_noise=true)
+  Z = pCN(ts1, noise1, 1.0)
+  (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(κg2, message, (x0, ll0), EM(false), Z)
 
   @test ll1 ≈ ll2
   @test isapprox(u1, u2, rtol=1e-14)
-  @test isapprox(noise1.W, noise2.W, rtol=1e-14)
+  @test isapprox(noise1, noise2, rtol=1e-14)
 
 
   # check guiding with matrix-valued diffusion
@@ -549,14 +545,14 @@ end
   kg3 = MSDE.SDEKernel(f, gmat, trange, θ, Σ(θ), true)
 
   # inplace=true
-  Z = pCN(noise1, 1.0)
-  ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z)
+  Z = pCN(ts1, noise1, 1.0)
+  (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z)
   @test ll1 ≈ ll3
   @test isapprox(u1, u3, rtol=1e-14)
 
   # inplace=false
-  Z = pCN(noise1, 1.0)
-  ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z, inplace=false)
+  Z = pCN(ts1, noise1, 1.0)
+  (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z, inplace=false)
   @test ll1 ≈ ll3
   @test isapprox(u1, u3, rtol=1e-14)
 end
@@ -601,7 +597,7 @@ end
   k3 = MSDE.SDEKernel(Mitosis.AffineMap(θlin[1], θlin[2]), Mitosis.ConstantMap(θlin[3]), trange, θlin, Σ(θlin))
 
 
-  _, sol, solend,_ = MSDE.sample(k1, u0, EM(false), save_noise=true)
+  solend, (_, sol, _) = MSDE.sample(k1, u0, EM(false), save_noise=true)
   v = solend
   c = randn()
   Pmat = randn(d,d)
@@ -620,13 +616,13 @@ end
   ll0 = randn()
 
   @testset "StochasticDiffEq EM() solver" begin
-    ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), EM(false); save_noise=true)
-    Z = pCN(noise1, 1.0)
-    ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), EM(false), Z; save_noise=true)
-    Z = pCN(noise1, 1.0)
-    ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), EM(false), Z; save_noise=true)
-    Z = pCN(noise1, 1.0)
-    ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), Z; save_noise=true)
+    (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(k1, message1, (u0, ll0), EM(false); save_noise=true)
+    Z = pCN(ts1, noise1, 1.0)
+    (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(k2, message2, (u0, ll0), EM(false), Z; save_noise=true)
+    Z = pCN(ts1, noise1, 1.0)
+    (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(k3, message3, (u0, ll0), EM(false), Z; save_noise=true)
+    Z = pCN(ts1, noise1, 1.0)
+    (uend4, ll4), (ts4, u4, noise4) = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), Z; save_noise=true)
 
     @test u1 ≈ u2 rtol=1e-14
     @test u1 ≈ u3 rtol=1e-14
@@ -639,13 +635,13 @@ end
   @testset "internal solver" begin
     @testset "without passing a noise" begin
       Random.seed!(seed)
-      ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      (uend4, ll4), (ts4, u4, noise4) = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       @test isapprox(uend1,uend2,rtol=1e-14)
       @test isapprox(uend1,uend3,rtol=1e-14)
       @test isapprox(uend1,uend4,rtol=1e-14)
@@ -659,14 +655,12 @@ end
                 for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      Wsaug = [vcat(W,zero(eltype(W))) for W in Ws]
-      NGaug = NoiseGrid(trange,Wsaug)
 
-      tsEM, uEM, uendEM, noiseEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
-      ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      (uendEM, llEM), (tsEM, uEM, noiseEM) = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NG, inplace=false)
+      (uend1, ll1), (ts1, u1, noise1) = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      (uend4, ll4), (ts4, u4, noise4) = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
 
       @test u1 ≈ uEM rtol=1e-12
       @test llEM ≈ ll1 rtol=1e-12
@@ -685,14 +679,11 @@ end
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      Wsaug = [vcat(W,zero(eltype(W))) for W in Ws]
-      NGaug = NoiseGrid(trange,Wsaug)
-
-      tsEM, uEM, uendEM, noiseEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
-      ts1, u1, uend1, noise1, ll1  = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      (uendEM, llEM), (tsEM, uEM, noiseEM) = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NG, inplace=false)
+      (uend1, ll1), (ts1, u1, noise1)  = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      (uend2, ll2), (ts2, u2, noise2) = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      (uend3, ll3), (ts3, u3, noise3) = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      (uend4, ll4), (ts4, u4, noise4) = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
 
       @test u1 ≈ uEM rtol=1e-12
       @test llEM ≈ ll1 rtol=1e-12

--- a/test/guiding_test.jl
+++ b/test/guiding_test.jl
@@ -106,14 +106,14 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
   x0 = randn()
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
+  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
 
 
-  dWs = (solfw.W[1,2:end]-solfw.W[1,1:end-1])
+  dWs = (noise1[1,2:end]-noise1[1,1:end-1])
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs)
 
-  @test isapprox(solfw[1,:], solfw2, rtol=1e-12)
+  @test isapprox(getindex.(u1,1), solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 
   # multivariate tests with scalar random process
@@ -140,12 +140,12 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
 
   x0 = randn(dim)
   ll0 = randn()
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG)
+  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG)
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0), ps, W)
 
-  @test isapprox(Array(solfw)[1:dim,:], hcat(solfw2 ...), rtol=1e-12)
+  @test isapprox(u1, solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 
   # multivariate tests with diagonal noise random process
@@ -167,19 +167,20 @@ g(u,p,t) = p[3] .- 0.2*(1 .-sin.(u))
   x0 = randn(dim)
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
+  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true)
 
-  Ws = Array(solfw.W)
-  dWs = Ws[1:dim,2:end]-Ws[1:dim,1:end-1]
+  dWs = noise1[1:dim,2:end]-noise1[1:dim,1:end-1]
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs,:diag)
 
-  @test isapprox(Array(solfw)[1:dim,:], hcat(solfw2 ...), rtol=1e-12)
+  @test isapprox(u1, solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 end
 
+
 @testset "OOP Guiding tests" begin
+
   # set true model parameters
   p = [-0.1,0.2,0.9]
 
@@ -212,14 +213,13 @@ end
   x0 = randn()
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
+  ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
 
-
-  dWs = (solfw.W[1,2:end]-solfw.W[1,1:end-1])
+  dWs = (noise1[1,2:end]-noise1[1,1:end-1])
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs)
 
-  @test isapprox(solfw[1,:], solfw2, rtol=1e-12)
+  @test isapprox(getindex.(u1,1), solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 
   # multivariate tests with scalar random process
@@ -246,12 +246,12 @@ end
 
   x0 = randn(dim)
   ll0 = randn()
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG, inplace=false)
+  ts1, u1, uend1, noise1, ll  = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(false), NG, inplace=false)
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0), ps, W)
 
-  @test isapprox(Array(solfw)[1:dim,:], hcat(solfw2 ...), rtol=1e-12)
+  @test isapprox(u1, solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 
   # multivariate tests with diagonal noise random process
@@ -273,18 +273,17 @@ end
   x0 = randn(dim)
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
+  ts1, u1, uend1, noise1, ll  = MSDE.forwardguiding(sdekernel, message, (x0, ll0); save_noise=true, inplace=false)
 
-  Ws = Array(solfw.W)
+  Ws = Array(noise1)
   dWs = Ws[1:dim,2:end]-Ws[1:dim,1:end-1]
 
   ps = message.soldis
   solfw2, ll2 = forwardguiding(plin, pest, message.ts, (x0, ll0),ps,dWs,:diag)
 
-  @test isapprox(Array(solfw)[1:dim,:], hcat(solfw2 ...), rtol=1e-12)
+  @test isapprox(u1, solfw2, rtol=1e-12)
   @test isapprox(ll, ll2, rtol=1e-12)
 end
-
 
 
 
@@ -328,22 +327,25 @@ end
   x0 = randn()
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
+  ts1, u1, uend1, _, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
             W; dt=dt, isadaptive=false)
-  solfw2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
+  ts2, u2, uend2, _, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), LambaEM(),
             W; dt=dt, isadaptive=true)
-  solfw3, ll3 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), SOSRI(),
+  ts3, u3, uend3, _, ll3 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), SOSRI(),
             W; dt=dt, isadaptive=true)
 
   @test isapprox(ll, ll2, rtol=1e-1)
   @test isapprox(ll, ll3, rtol=1e-1)
   @test isapprox(ll2, ll2, rtol=1e-1)
-  @test isapprox(solfw(solfw2.t).u, solfw2.u, rtol=1e-1)
-  @test isapprox(solfw(solfw3.t).u, solfw3.u, rtol=1e-1)
 
-  @show length(solfw.t), length(solfw2.t), length(solfw3.t)
+  @test length(ts1) == length(trange)
+  @test length(ts2) < length(ts1)
+  @test length(ts3) < length(ts1)
 
+  @show length(ts1), length(ts2), length(ts3)
 end
+
+
 
 @testset "timechange Guiding tests" begin
   Random.seed!(12345)
@@ -379,12 +381,12 @@ end
   x0 = randn()
   ll0 = randn()
 
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0);
+  ts, u, uend, _, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0);
     isadaptive=false)
 
-  @test isapprox(solfw.t, message.ts, rtol=1e-10)
-  @test isapprox(solfw.t, MSDE.timechange(trange), rtol=1e-10)
-  @test length(solfw.t) == length(trange)
+  @test isapprox(ts, message.ts, rtol=1e-10)
+  @test isapprox(ts, MSDE.timechange(trange), rtol=1e-10)
+  @test length(ts) == length(trange)
 end
 
 @testset "Reuse of noise values tests" begin
@@ -428,25 +430,25 @@ end
   ll0 = randn()
 
   # test two subsequent evaluations with same Brownian motion given by NoiseGrid
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
-  solfw2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
+  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
+  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), W; dt=dt)
 
-  @test isapprox(ll, ll2, rtol=1e-14)
-  @test isapprox(solfw.u, solfw2.u, rtol=1e-14)
-  @test isapprox(solfw.W.W, solfw2.W.W, rtol=1e-14)
-  @test isapprox(solfw.W.W, W.W, rtol=1e-14)
+  @test isapprox(ll1, ll2, rtol=1e-14)
+  @test isapprox(u1, u2, rtol=1e-14)
+  @test isapprox(noise1.W, noise2.W, rtol=1e-14)
+  @test isapprox(noise1.W, W.W, rtol=1e-14)
 
   # test pCN with \rho = 1
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
+  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
 
-  Z = pCN(solfw.W, 1.0)
+  Z = pCN(noise1, 1.0)
 
-  solfw2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
+  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
 
-  @test isapprox(ll, ll2, rtol=1e-14)
-  @test isapprox(solfw.u, solfw2.u, rtol=1e-14)
-  @test isapprox(solfw.W.W, solfw2.W.W, rtol=1e-14)
-  @test isapprox(solfw.W.W, Z.W, rtol=1e-14)
+  @test isapprox(ll1, ll2, rtol=1e-14)
+  @test isapprox(u1, u2, rtol=1e-14)
+  @test isapprox(noise1.W, noise1.W, rtol=1e-14)
+  @test isapprox(noise1.W, Z.W, rtol=1e-14)
   @test W.W != Z.W
 
 
@@ -457,23 +459,23 @@ end
   # backward kernel
   kerneltilde = MSDE.SDEKernel(Mitosis.AffineMap(B, β), Mitosis.ConstantMap(σ̃), trange, plin)
   message, backward = MSDE.backwardfilter(kerneltilde, NT)
-  solfw, ll = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
+  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(); dt=dt, save_noise=true)
 
-  Z = pCN(solfw.W, ρ)
+  Z = pCN(noise1, ρ)
 
-  solfw2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
+  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(sdekernel, message, (x0, ll0), EM(), Z; dt=dt)
 
   computedW(W, indx, dt) = (W[indx+1][1]-W[indx][1])/sqrt(dt) # likelihood part can be ignored
   dWnew = []
   dWold = []
-  for i in 1:length(solfw.t[1:end-1])
-    push!(dWnew,computedW(solfw.W.W,i,dt))
-    push!(dWold,computedW(solfw2.W.W,i,dt))
+  for i in 1:length(ts1[1:end-1])
+    push!(dWnew,computedW(noise1.W,i,dt))
+    push!(dWold,computedW(noise2.W,i,dt))
   end
   @show cor(dWnew,dWold)
   @test ≈(cor(dWnew,dWold),ρ,rtol=1e-1)
-
 end
+
 
 
 @testset "flag-constant and matrix-valued diffusivity tests" begin
@@ -511,11 +513,11 @@ end
   κ̃ = MSDE.SDEKernel(Mitosis.AffineMap(θlin[1], θlin[2]), Mitosis.ConstantMap(θlin[3]), trange, θlin)
 
   # forward sample
-  x, xT = MSDE.sample(κ1, u0; save_noise=true)
-  Z = NoiseWrapper(x.W)
-  x2, xT2 = MSDE.sample(κ2, u0, EM(false), Z)
+  ts, x, xT, noise = MSDE.sample(κ1, u0; save_noise=true)
+  Z = NoiseWrapper(noise)
+  _, x2, xT2,_ = MSDE.sample(κ2, u0, EM(false), Z)
 
-  @test x.u ≈ x2.u
+  @test x ≈ x2
   @test xT ≈ xT2
 
   # backward filter
@@ -533,13 +535,13 @@ end
   x0 = randn(d)
   ll0 = randn()
 
-  solfw1, ll1 = MSDE.forwardguiding(κg1, message, (x0, ll0); save_noise=true)
-  Z = pCN(solfw1.W, 1.0)
-  solfw2, ll2 = MSDE.forwardguiding(κg2, message, (x0, ll0), EM(false), Z)
+  ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(κg1, message, (x0, ll0); save_noise=true)
+  Z = pCN(noise1, 1.0)
+  ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(κg2, message, (x0, ll0), EM(false), Z)
 
   @test ll1 ≈ ll2
-  @test isapprox(solfw1.u, solfw2.u, rtol=1e-14)
-  @test isapprox(solfw1.W.W, solfw2.W.W, rtol=1e-14)
+  @test isapprox(u1, u2, rtol=1e-14)
+  @test isapprox(noise1.W, noise2.W, rtol=1e-14)
 
 
   # check guiding with matrix-valued diffusion
@@ -547,21 +549,21 @@ end
   kg3 = MSDE.SDEKernel(f, gmat, trange, θ, Σ(θ), true)
 
   # inplace=true
-  Z = pCN(solfw1.W, 1.0)
-  solfw3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z)
+  Z = pCN(noise1, 1.0)
+  ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z)
   @test ll1 ≈ ll3
-  @test isapprox(solfw1.u, solfw3.u, rtol=1e-14)
+  @test isapprox(u1, u3, rtol=1e-14)
 
   # inplace=false
-  Z = pCN(solfw1.W, 1.0)
-  solfw3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z, inplace=false)
+  Z = pCN(noise1, 1.0)
+  ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(kg3, message, (x0, ll0), EM(false), Z, inplace=false)
   @test ll1 ≈ ll3
-  @test isapprox(solfw1.u, solfw3.u, rtol=1e-14)
+  @test isapprox(u1, u3, rtol=1e-14)
 end
 
 
 
-@testset "multivariate forward guidng tests" begin
+@testset "multivariate forward guiding tests" begin
   seed = 12345
   Random.seed!(seed)
   d = 2
@@ -599,7 +601,7 @@ end
   k3 = MSDE.SDEKernel(Mitosis.AffineMap(θlin[1], θlin[2]), Mitosis.ConstantMap(θlin[3]), trange, θlin, Σ(θlin))
 
 
-  sol, solend = MSDE.sample(k1, u0, EM(false), save_noise=true)
+  _, sol, solend,_ = MSDE.sample(k1, u0, EM(false), save_noise=true)
   v = solend
   c = randn()
   Pmat = randn(d,d)
@@ -618,17 +620,17 @@ end
   ll0 = randn()
 
   @testset "StochasticDiffEq EM() solver" begin
-    sol1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), EM(false); save_noise=true)
-    Z = pCN(sol1.W, 1.0)
-    sol2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), EM(false), Z; save_noise=true)
-    Z = pCN(sol1.W, 1.0)
-    sol3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), EM(false), Z; save_noise=true)
-    Z = pCN(sol1.W, 1.0)
-    sol4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), Z; save_noise=true)
+    ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), EM(false); save_noise=true)
+    Z = pCN(noise1, 1.0)
+    ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), EM(false), Z; save_noise=true)
+    Z = pCN(noise1, 1.0)
+    ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), EM(false), Z; save_noise=true)
+    Z = pCN(noise1, 1.0)
+    ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), Z; save_noise=true)
 
-    @test sol1.u ≈ sol2.u rtol=1e-14
-    @test sol1.u ≈ sol3.u rtol=1e-14
-    @test sol1.u ≈ sol4.u rtol=1e-14
+    @test u1 ≈ u2 rtol=1e-14
+    @test u1 ≈ u3 rtol=1e-14
+    @test u1 ≈ u4 rtol=1e-14
     @test ll1 == ll2
     @test ll1 == ll3
     @test ll1 == ll4
@@ -637,16 +639,16 @@ end
   @testset "internal solver" begin
     @testset "without passing a noise" begin
       Random.seed!(seed)
-      sol1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      sol2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      sol3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
       Random.seed!(seed)
-      sol4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
-      @test minimum(isapprox.(sol1[end],sol2[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol3[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol4[end],rtol=1e-14))
+      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), inplace=false)
+      @test isapprox(uend1,uend2,rtol=1e-14)
+      @test isapprox(uend1,uend3,rtol=1e-14)
+      @test isapprox(uend1,uend4,rtol=1e-14)
       @test ll1 == ll2
       @test ll1 == ll3
       @test ll1 == ll4
@@ -660,18 +662,18 @@ end
       Wsaug = [vcat(W,zero(eltype(W))) for W in Ws]
       NGaug = NoiseGrid(trange,Wsaug)
 
-      solEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
-      sol1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      sol2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      sol3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
-      sol4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      tsEM, uEM, uendEM, noiseEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
+      ts1, u1, uend1, noise1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
+      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), NG, inplace=false)
 
-      @test hcat(getindex.(sol1,3)...) ≈ solEM[1:2,:] rtol=1e-12
+      @test u1 ≈ uEM rtol=1e-12
       @test llEM ≈ ll1 rtol=1e-12
 
-      @test minimum(isapprox.(sol1[end],sol2[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol3[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol4[end],rtol=1e-14))
+      @test isapprox(uend1,uend2,rtol=1e-14)
+      @test isapprox(uend1,uend3,rtol=1e-14)
+      @test isapprox(uend1,uend4,rtol=1e-14)
       @test ll1 == ll2
       @test ll1 == ll3
       @test ll1 == ll4
@@ -686,22 +688,21 @@ end
       Wsaug = [vcat(W,zero(eltype(W))) for W in Ws]
       NGaug = NoiseGrid(trange,Wsaug)
 
-      solEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
-      sol1, ll1 = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      sol2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      sol3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
-      sol4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      tsEM, uEM, uendEM, noiseEM, llEM = MSDE.forwardguiding(k3, message4, (u0, ll0), EM(false), NGaug, inplace=false)
+      ts1, u1, uend1, noise1, ll1  = MSDE.forwardguiding(k1, message1, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      ts2, u2, uend2, noise2, ll2 = MSDE.forwardguiding(k2, message2, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      ts3, u3, uend3, noise3, ll3 = MSDE.forwardguiding(k3, message3, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
+      ts4, u4, uend4, noise4, ll4 = MSDE.forwardguiding(k3, message4, (u0, ll0), MSDE.EulerMaruyama!(), Ws, inplace=false)
 
-      @test hcat(getindex.(sol1,3)...) ≈ solEM[1:2,:] rtol=1e-12
+      @test u1 ≈ uEM rtol=1e-12
       @test llEM ≈ ll1 rtol=1e-12
 
-      @test minimum(isapprox.(sol1[end],sol2[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol3[end],rtol=1e-14))
-      @test minimum(isapprox.(sol1[end],sol4[end],rtol=1e-14))
+      @test isapprox(uend1,uend2,rtol=1e-14)
+      @test isapprox(uend1,uend3,rtol=1e-14)
+      @test isapprox(uend1,uend4,rtol=1e-14)
       @test ll1 == ll2
       @test ll1 == ll3
       @test ll1 == ll4
     end
-
   end
 end

--- a/test/mitosis_test.jl
+++ b/test/mitosis_test.jl
@@ -34,7 +34,7 @@ sdekerneltilde2 = MSDE.SDEKernel(f,g,trange,plin2)
 
 
 
-sol, y_ = MSDE.sample(sdekernel, u0, save_noise=true)
+ts, sol, y_ = MSDE.sample(sdekernel, u0, save_noise=true)
 
 y_ = 1.39
 y = vcat(y_)
@@ -93,11 +93,11 @@ pT = kᵒ([u0])
 WG = WGaussian{(:μ,:Σ,:c)}(y_, 0.2, 0.0) # start with observation μ=y with uncertainty Σ=0.1
 message, solend = MSDE.backwardfilter(sdekernel, WG)
 
-solfw, ll = MSDE.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)
+ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)
 
 @test ll == 0
 
-samples = [MSDE.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)[1][1,end] for k in 1:K]
+samples = [MSDE.forwardguiding(sdekernel, message, (u0, 0.0), Z=nothing; save_noise=true)[2][end][1] for k in 1:K]
 
 @testset "Mitosis forward" begin
     @test pT.μ[] ≈ mean(samples) atol=atol
@@ -117,10 +117,14 @@ message, solend = MSDE.backwardfilter(sdekerneltilde2, WG)
     @test inv(p2.Γ)[] ≈ solend.Σ atol=atol
 end
 
-solfw, ll = MSDE.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)
+ts1, u1, uend1, noise1, ll = MSDE.forwardguiding(sdekernel2, message, (u0, 0.0))
 
 we((x,c)) = x*exp(c)
-samples2 = [MSDE.forwardguiding(sdekernel2, message, (u0, 0.0), Z=nothing; save_noise=true)[1][:,end] for k in 1:K]
+samples2 = []
+for k=1:K
+    _, u1, uend1, _, _ll = MSDE.forwardguiding(sdekernel2, message, (u0, 0.0))
+    push!(samples2,[uend1[1], ll])
+end
 
 samples = we.(samples2)
 

--- a/test/regression_test.jl
+++ b/test/regression_test.jl
@@ -87,10 +87,10 @@ end
 
   # sample using MSDE and EM default
   Random.seed!(100)
-  ts, u, uend, noise = MSDE.sample(sdekernel, u0, save_noise=true)
+  uend, (ts, u, noise) = MSDE.sample(sdekernel, u0, save_noise=true)
   Random.seed!(100)
   # for later AD check
-  ts2, u2, uend2, noise2 = MSDE.sample(sdekernel, [u0], save_noise=true)
+  uend2, (ts2, u2, noise2) = MSDE.sample(sdekernel, [u0], save_noise=true)
   @show uend
   @show length(u)
 

--- a/test/regression_test.jl
+++ b/test/regression_test.jl
@@ -106,7 +106,7 @@ end
   G2 = MSDE.conjugate(R2, u, 0.1*I(2), ts)
   G3 = MSDE.conjugate(R3, u, 0.1*I(2), ts)
   G4 = MSDE.conjugate(R4, u, 0.1*I(2), ts)
-  Gtest = conjugate_posterior(ts, u, 0.1*I(2), par, g)
+  Gtest = conjugate_posterior(ts, u, 0.1*I(2), par, goop)
 
   @testset "Regression! oop tests" begin
     @test G ≈ Gtest rtol=1e-10
@@ -257,7 +257,7 @@ end
 
   G = MSDE.conjugate(R, sol, 0.1*I(2))
   G2 = MSDE.conjugate(R2, sol, 0.1*I(2))
-  G3 = conjugate_posterior(sol, 0.1*I(2))
+  G3 = conjugate_posterior(sol.t, sol.u, 0.1*I(2), par, goop)
 
   @testset "iip tests" begin
     @test G ≈ G3 rtol=1e-10

--- a/test/sample_test.jl
+++ b/test/sample_test.jl
@@ -46,9 +46,9 @@ end
   sol, solend = MSDE.sample(kernel, u0)
 
   kernel = MSDE.SDEKernel(f,g,collect(trange),p)
-  sol, solend = MSDE.sample(kernel, u0, save_noise=true)
+  ts, u, uend, noise = MSDE.sample(kernel, u0, save_noise=true)
 
-  @test isapprox(sol.u, forwardsample(f,g,p,sol.t,sol.W.W,sol.prob.u0), atol=1e-12)
+  @test isapprox(u, forwardsample(f,g,p,ts,noise.W,u0), atol=1e-12)
 end
 
 
@@ -104,59 +104,59 @@ end
   k6 = MSDE.SDEKernel!(f!,g!,gstep!,trange,θlin,A; ws = copy(A))
 
   @testset "StochasticDiffEq EM() solver" begin
-    sol1, solend1 = MSDE.sample(k1, u0, EM(false), save_noise=true)
-    Z = pCN(sol1.W, 1.0)
-    sol2, solend2 = MSDE.sample(k2, u0, EM(false), Z, save_noise=true)
-    Z = pCN(sol1.W, 1.0)
-    sol3, solend3 = MSDE.sample(k3, u0, EM(false), Z)
-    Z = pCN(sol1.W, 1.0)
-    sol4, solend4 = MSDE.sample(k4, u0, EM(false), Z)
-    Z = pCN(sol1.W, 1.0)
-    sol5, solend5 = MSDE.sample(k5, u0, EM(false), Z)
-    Z = pCN(sol1.W, 1.0)
-    sol6, solend6 = MSDE.sample(k6, u0, EM(false), Z)
+    _, u1, uend1, noise1 = MSDE.sample(k1, u0, EM(false), save_noise=true)
+    Z = pCN(noise1, 1.0)
+    _, u2, uend2, _ = MSDE.sample(k2, u0, EM(false), Z, save_noise=true)
+    Z = pCN(noise1, 1.0)
+    _, u3, uend3, _ = MSDE.sample(k3, u0, EM(false), Z)
+    Z = pCN(noise1, 1.0)
+    _, u4, uend4, _ = MSDE.sample(k4, u0, EM(false), Z)
+    Z = pCN(noise1, 1.0)
+    _, u5, uend5, _ = MSDE.sample(k5, u0, EM(false), Z)
+    Z = pCN(noise1, 1.0)
+    _, u6, uend6, _ = MSDE.sample(k6, u0, EM(false), Z)
 
     #@show solend1
-    @test isapprox(sol1.u, sol2.u, atol=1e-12)
-    @test isapprox(solend1, solend2, atol=1e-12)
-    @test isapprox(sol1.u, sol3.u, atol=1e-12)
-    @test isapprox(solend1, solend3, atol=1e-12)
-    @test isapprox(sol1.u, sol4.u, atol=1e-12)
-    @test isapprox(solend1, solend4, atol=1e-12)
-    @test isapprox(sol1.u, sol5.u, atol=1e-12)
-    @test isapprox(solend1, solend5, atol=1e-12)
-    @test isapprox(sol1.u, sol6.u, atol=1e-12)
-    @test isapprox(solend1, solend6, atol=1e-12)
+    @test isapprox(u1, u2, atol=1e-12)
+    @test isapprox(uend1, uend2, atol=1e-12)
+    @test isapprox(u1, u3, atol=1e-12)
+    @test isapprox(uend1, uend3, atol=1e-12)
+    @test isapprox(u1, u4, atol=1e-12)
+    @test isapprox(uend1, uend4, atol=1e-12)
+    @test isapprox(u1, u5, atol=1e-12)
+    @test isapprox(uend1, uend5, atol=1e-12)
+    @test isapprox(u1, u6, atol=1e-12)
+    @test isapprox(uend1, uend6, atol=1e-12)
   end
 
   @testset "internal solver" begin
     @testset "without passing a noise" begin
       Random.seed!(seed)
-      sol1, solend1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), save=true)
+      ts1, u1, uend1, _ = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), save=true)
       Random.seed!(seed)
-      sol2, solend2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), save=true)
+      _, u2, uend2, _ = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), save=true)
       Random.seed!(seed)
       # inplace must be written out manually
-      @test_broken ol3, solend3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), save=true)
+      @test_broken _, u3, uend3, _ = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), save=true)
       Random.seed!(seed)
-      sol4, solend4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), save=true)
+      _, u4, uend4, _ = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), save=true)
       Random.seed!(seed)
-      sol5, solend5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), save=true)
+      _, u5, uend5, _ = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), save=true)
       Random.seed!(seed)
-      sol6, solend6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), save=true)
+      _, u6, uend6, _ = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), save=true)
 
-      @test solend1[1] == length(trange)
-      @test solend1[2] == trange[end]
-      @test solend1 == solend2
-      @test_broken solend1 == solend3
-      @test solend1 == solend4
-      @test solend1 == solend5
-      @test solend1 == solend6
+      @test length(ts1) == length(trange)
+      @test ts1[end] == trange[end]
+      @test uend1 == uend2
+      @test_broken uend1 == uend3
+      @test uend1 == uend4
+      @test uend1 == uend5
+      @test uend1 == uend6
 
       Random.seed!(seed)
-      sol5, solend5 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), save=false)
-      @test solend1 == solend5
-      @test sol5 === nothing
+      _, u7, uend7, _ = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), save=false)
+      @test uend1 == uend7
+      @test u7 === nothing
     end
 
     @testset "passing a noise grid" begin
@@ -165,21 +165,21 @@ end
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      solEM, solendEM = MSDE.sample(k1, u0, EM(false), NG)
-      sol1, solend1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), NG)
-      sol2, solend2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), NG)
-      @test_broken ol3, solend3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), NG)
-      sol4, solend4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), NG)
-      sol5, solend5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), NG)
-      sol6, solend6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), NG)
+      tsEM, uEM, uendEM, noiseEM = MSDE.sample(k1, u0, EM(false), NG)
+      ts1, u1, uend1, noise1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), NG)
+      ts2, u2, uend2, noise2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), NG)
+      @test_broken ts3, u3, uend3, noise3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), NG)
+      ts4, u4, uend4, noise4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), NG)
+      ts5, u5, uend5, noise5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), NG)
+      ts6, u6, uend6, noise6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), NG)
 
-      @test getindex.(sol1,3) ≈ solEM.u rtol=1e-12
-      @test solendEM ≈ solend1[3] rtol=1e-12
-      @test solendEM ≈ solend2[3] rtol=1e-12
-      @test_broken solendEM ≈ solend3[3] rtol=1e-12
-      @test solendEM ≈ solend4[3] rtol=1e-12
-      @test solendEM ≈ solend5[3] rtol=1e-12
-      @test solendEM ≈ solend6[3] rtol=1e-12
+      @test u1 ≈ uEM rtol=1e-12
+      @test uendEM ≈ uend1 rtol=1e-12
+      @test uendEM ≈ uend2 rtol=1e-12
+      @test_broken uendEM ≈ uend3 rtol=1e-12
+      @test uendEM ≈ uend4 rtol=1e-12
+      @test uendEM ≈ uend5 rtol=1e-12
+      @test uendEM ≈ uend6 rtol=1e-12
     end
 
     @testset "passing the noise values" begin
@@ -188,21 +188,21 @@ end
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      solEM, solendEM = MSDE.sample(k1, u0, EM(false), NG)
-      sol1, solend1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), Ws)
-      sol2, solend2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), Ws)
-      @test_broken ol3, solend3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), Ws)
-      sol4, solend4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), Ws)
-      sol5, solend5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), Ws)
-      sol6, solend6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), Ws)
+      tsEM, uEM, uendEM, noiseEM  = MSDE.sample(k1, u0, EM(false), NG)
+      ts1, u1, uend1, noise1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), Ws)
+      ts2, u2, uend2, noise2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), Ws)
+      @test_broken ts3, u3, uend3, noise3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), Ws)
+      ts4, u4, uend4, noise4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), Ws)
+      ts5, u5, uend5, noise5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), Ws)
+      ts6, u6, uend6, noise6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), Ws)
 
-      @test getindex.(sol1,3) ≈ solEM.u rtol=1e-12
-      @test solendEM ≈ solend1[3] rtol=1e-12
-      @test solendEM ≈ solend2[3] rtol=1e-12
-      @test_broken solendEM ≈ solend3[3] rtol=1e-12
-      @test solendEM ≈ solend4[3] rtol=1e-12
-      @test solendEM ≈ solend5[3] rtol=1e-12
-      @test solendEM ≈ solend6[3] rtol=1e-12
+      @test u1 ≈ uEM rtol=1e-12
+      @test uendEM ≈ uend1 rtol=1e-12
+      @test uendEM ≈ uend2 rtol=1e-12
+      @test_broken uendEM ≈ uend3 rtol=1e-12
+      @test uendEM ≈ uend4 rtol=1e-12
+      @test uendEM ≈ uend5 rtol=1e-12
+      @test uendEM ≈ uend6 rtol=1e-12
     end
 
     @testset "custom P" begin
@@ -229,21 +229,21 @@ end
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      solEM, solendEM = MSDE.sample(k1, u0, EM(false), NG)
-      sol1, solend1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
-      sol2, solend2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
-      sol3, solend3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
-      sol4, solend4 = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), Ws)
-      sol5, solend5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), Ws)
-      sol6, solend6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), Ws)
+      tsEM, uEM, uendEM, noiseEM = MSDE.sample(k1, u0, EM(false), NG)
+      ts1, u1, uend1, noise1 = MSDE.sample(k1, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
+      ts2, u2, uend2, noise2 = MSDE.sample(k2, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
+      ts3, u3, uend3, noise3 = MSDE.sample(k3, u0, MSDE.EulerMaruyama!(), Ws, P=customP(θlin))
+      ts4, u4, uend4, noise4  = MSDE.sample(k4, u0, MSDE.EulerMaruyama!(), Ws)
+      ts5, u5, uend5, noise5 = MSDE.sample(k5, u0, MSDE.EulerMaruyama!(), Ws)
+      ts6, u6, uend6, noise6 = MSDE.sample(k6, u0, MSDE.EulerMaruyama!(), Ws)
 
-      @test getindex.(sol1,3) ≈ solEM.u rtol=1e-12
-      @test solendEM ≈ solend1[3] rtol=1e-12
-      @test solendEM ≈ solend2[3] rtol=1e-12
-      @test solendEM ≈ solend3[3] rtol=1e-12
-      @test solendEM ≈ solend4[3] rtol=1e-12
-      @test solendEM ≈ solend5[3] rtol=1e-12
-      @test solendEM ≈ solend6[3] rtol=1e-12
+      @test u1 ≈ uEM rtol=1e-12
+      @test uendEM ≈ uend1 rtol=1e-12
+      @test uendEM ≈ uend2 rtol=1e-12
+      @test uendEM ≈ uend3 rtol=1e-12
+      @test uendEM ≈ uend4 rtol=1e-12
+      @test uendEM ≈ uend5 rtol=1e-12
+      @test uendEM ≈ uend6 rtol=1e-12
     end
 
   end

--- a/test/solver_convergence_test.jl
+++ b/test/solver_convergence_test.jl
@@ -1,4 +1,5 @@
 import MitosisStochasticDiffEq as MSDE
+using Mitosis, DiffEqNoiseProcess, StochasticDiffEq
 using Test, Random
 using LinearAlgebra
 
@@ -26,11 +27,12 @@ using LinearAlgebra
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      solEM, solendEM = MSDE.sample(kernel, u0, EM(false), NG)
-      sol1, solend1 = MSDE.sample(kernel, u0, MSDE.EulerMaruyama!(), Ws)
+      tsEM, uEM, uendEM, noiseEM = MSDE.sample(kernel, u0, EM(false), NG)
+      ts1, u1, uend1, noise1 = MSDE.sample(kernel, u0, MSDE.EulerMaruyama!(), Ws)
 
-      @test getindex.(sol1,3) ≈ solEM.u rtol=1e-12
-      @test solendEM ≈ solend1[3] rtol=1e-12
+      @test tsEM ≈ ts1 rtol=1e-12
+      @test uEM ≈ u1 rtol=1e-12
+      @test uendEM ≈ uend1 rtol=1e-12
     end
   end
 

--- a/test/solver_convergence_test.jl
+++ b/test/solver_convergence_test.jl
@@ -27,8 +27,8 @@ using LinearAlgebra
               for (i,ti) in enumerate(trange[1:end-1])]])
       NG = NoiseGrid(trange,Ws)
 
-      tsEM, uEM, uendEM, noiseEM = MSDE.sample(kernel, u0, EM(false), NG)
-      ts1, u1, uend1, noise1 = MSDE.sample(kernel, u0, MSDE.EulerMaruyama!(), Ws)
+      uendEM, (tsEM, uEM, noiseEM) = MSDE.sample(kernel, u0, EM(false), NG)
+      uend1, (ts1, u1, noise1) = MSDE.sample(kernel, u0, MSDE.EulerMaruyama!(), Ws)
 
       @test tsEM ≈ ts1 rtol=1e-12
       @test uEM ≈ u1 rtol=1e-12

--- a/test/static_array_test.jl
+++ b/test/static_array_test.jl
@@ -46,8 +46,8 @@ Random.seed!(seed)
 samples2 = MSDE.sample(sdekernel2, u0stat, save_noise=false)
 
 @test isapprox(samples1[1], samples2[1], rtol=1e-10)
-@test isapprox(samples1[3], samples2[3], rtol=1e-10)
-@test typeof(samples2[3]) <: SArray
+@test isapprox(samples1[2][3], samples2[2][3], rtol=1e-10)
+@test typeof(samples2[2][2][end]) <: SArray
 
 
 # initial values for ODE
@@ -80,10 +80,10 @@ Random.seed!(seed)
 samples2 = MSDE.forwardguiding(sdekernel2, message2,
   (x0stat, ll0), inplace=false)
 
-@test isapprox(samples1[1], samples2[1], rtol=1e-10)
-@test isapprox(samples1[2], samples2[2], rtol=1e-10)
+@test isapprox(samples1[2][1], samples2[2][1], rtol=1e-10)
+@test isapprox(samples1[2][2], samples2[2][2], rtol=1e-10)
 @test_broken typeof(samples2[2][end]) <: SArray
-@test typeof(samples2[3]) <: SArray
+@test_broken typeof(samples2[3]) <: SArray
 end
 
 @testset "static tilde parameter tests" begin

--- a/test/static_array_test.jl
+++ b/test/static_array_test.jl
@@ -82,7 +82,8 @@ samples2 = MSDE.forwardguiding(sdekernel2, message2,
 
 @test isapprox(samples1[1], samples2[1], rtol=1e-10)
 @test isapprox(samples1[2], samples2[2], rtol=1e-10)
-@test typeof(samples2[2][end]) <: SArray
+@test_broken typeof(samples2[2][end]) <: SArray
+@test typeof(samples2[3]) <: SArray
 end
 
 @testset "static tilde parameter tests" begin

--- a/test/static_array_test.jl
+++ b/test/static_array_test.jl
@@ -45,8 +45,9 @@ samples1 = MSDE.sample(sdekernel1, u0, save_noise=false)
 Random.seed!(seed)
 samples2 = MSDE.sample(sdekernel2, u0stat, save_noise=false)
 
-@test isapprox(samples1[2][1], samples2[2][1], rtol=1e-10)
-@test typeof(samples2[2]) <: SArray
+@test isapprox(samples1[1], samples2[1], rtol=1e-10)
+@test isapprox(samples1[3], samples2[3], rtol=1e-10)
+@test typeof(samples2[3]) <: SArray
 
 
 # initial values for ODE
@@ -79,8 +80,9 @@ Random.seed!(seed)
 samples2 = MSDE.forwardguiding(sdekernel2, message2,
   (x0stat, ll0), inplace=false)
 
-@test isapprox(samples1[2][1], samples2[2][1], rtol=1e-10)
-@test typeof(samples2[1][end]) <: SArray
+@test isapprox(samples1[1], samples2[1], rtol=1e-10)
+@test isapprox(samples1[2], samples2[2], rtol=1e-10)
+@test typeof(samples2[2][end]) <: SArray
 end
 
 @testset "static tilde parameter tests" begin


### PR DESCRIPTION
`sample` will from now on return: `ts, u, uend, noise`
`forwardguiding` will return:  `ts, u, uend, noise, ll`